### PR TITLE
feat(ai-chat): bexly agent http service + action confirmation card (phase 3.1 part B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,11 @@ GOOGLE_ANDROID_CLIENT_ID_RELEASE=your_release_client_id.apps.googleusercontent.c
 # PAYMENTS (Optional)
 # ============================================================
 STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
+
+# ============================================================
+# BEXLY AGENT (Phase 3.1 - default off)
+# Routes AI chat through the Bexly Agent server (Mastra + 21 MCP tools).
+# Set BEXLY_USE_AGENT=true to enable in dev; keep false in prod until stable.
+# ============================================================
+# BEXLY_USE_AGENT=false
+# BEXLY_AGENT_URL=https://bexly-agent.dos.ai

--- a/lib/core/config/llm_config.dart
+++ b/lib/core/config/llm_config.dart
@@ -122,4 +122,18 @@ class LLMDefaultConfig {
       'Authorization': 'Bearer $token',
     };
   }
+
+  // ==========================================================================
+  // Bexly Agent (Phase 3.1+)
+  // Routes AI chat through the Bexly Agent server (Mastra + 21 MCP tools).
+  // When false (default), the legacy ai-proxy + client-side action parsing
+  // path in ChatNotifier stays active. Flip to true in .env to exercise the
+  // agent path in dev before promoting to prod.
+  // ==========================================================================
+
+  /// Feature flag: when true, AI chat routes through the Bexly Agent (Mastra
+  /// + 21 MCP tools). When false, falls back to ai-proxy + client-side action
+  /// parsing (legacy behavior).
+  static bool get useBexlyAgent =>
+      const bool.fromEnvironment('BEXLY_USE_AGENT', defaultValue: false);
 }

--- a/lib/features/ai_chat/data/services/bexly_agent_service.dart
+++ b/lib/features/ai_chat/data/services/bexly_agent_service.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:bexly/core/utils/logger.dart';
+
+class BexlyAgentException implements Exception {
+  BexlyAgentException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'BexlyAgentException(${statusCode ?? "?"}): $message';
+}
+
+class BexlyAgentAuthException extends BexlyAgentException {
+  BexlyAgentAuthException(super.message) : super(statusCode: 401);
+}
+
+/// Calls Bexly Agent's `/api/agent/chat` and streams plain-text chunks.
+///
+/// Phase 3.1 ships text-only streaming (no Vercel AI SDK protocol). Tool calls
+/// execute server-side and surface as part of the agent reply. Phase 3.4 will
+/// switch to structured event streaming so the mobile can render action
+/// confirmation cards inline.
+class BexlyAgentService {
+  static const _label = 'BexlyAgentService';
+  static const _baseUrl = String.fromEnvironment(
+    'BEXLY_AGENT_URL',
+    defaultValue: 'https://bexly-agent.dos.ai',
+  );
+
+  Stream<String> chat({
+    required String message,
+    String? threadId,
+    String locale = 'vi',
+  }) async* {
+    final session = Supabase.instance.client.auth.currentSession;
+    if (session == null) {
+      throw BexlyAgentAuthException('Can not chat: no active session.');
+    }
+
+    final client = http.Client();
+    try {
+      final req = http.Request('POST', Uri.parse('$_baseUrl/api/agent/chat'))
+        ..headers['Authorization'] = 'Bearer ${session.accessToken}'
+        ..headers['Content-Type'] = 'application/json'
+        ..body = jsonEncode({
+          'message': message,
+          if (threadId != null) 'threadId': threadId,
+          'locale': locale,
+        });
+
+      final streamed = await client
+          .send(req)
+          .timeout(const Duration(seconds: 120));
+
+      if (streamed.statusCode == 401 || streamed.statusCode == 403) {
+        final body = await streamed.stream.bytesToString();
+        Log.w('agent ${streamed.statusCode}: $body', label: _label);
+        throw BexlyAgentAuthException('JWT invalid - please re-login.');
+      }
+      if (streamed.statusCode != 200) {
+        final body = await streamed.stream.bytesToString();
+        Log.e('agent ${streamed.statusCode}: $body', label: _label);
+        throw BexlyAgentException(
+          'Agent error ${streamed.statusCode}: $body',
+          statusCode: streamed.statusCode,
+        );
+      }
+
+      await for (final chunk in streamed.stream.transform(utf8.decoder)) {
+        if (chunk.isNotEmpty) yield chunk;
+      }
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/lib/features/ai_chat/data/services/bexly_agent_service.dart
+++ b/lib/features/ai_chat/data/services/bexly_agent_service.dart
@@ -38,9 +38,17 @@ class BexlyAgentService {
     String? threadId,
     String locale = 'vi',
   }) async* {
-    final session = Supabase.instance.client.auth.currentSession;
+    // Wrap currentSession access defensively - Supabase.instance throws if
+    // not initialized (hot-restart edge case, cold-start race). Treat as
+    // "no session" rather than crashing the chat flow.
+    Session? session;
+    try {
+      session = Supabase.instance.client.auth.currentSession;
+    } catch (_) {
+      session = null;
+    }
     if (session == null) {
-      throw BexlyAgentAuthException('Can not chat: no active session.');
+      throw BexlyAgentAuthException('Cannot chat: no active session.');
     }
 
     final client = http.Client();

--- a/lib/features/ai_chat/presentation/components/action_confirmation_card.dart
+++ b/lib/features/ai_chat/presentation/components/action_confirmation_card.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+import 'package:bexly/core/constants/app_colors.dart';
+import 'package:bexly/core/constants/app_spacing.dart';
+import 'package:bexly/core/constants/app_text_styles.dart';
+
+/// Render an agent tool call as a card the user can confirm or cancel.
+///
+/// Phase 3.4 will wire this into the chat stream once the agent endpoint
+/// emits structured tool-call events. For Phase 3.1, this widget exists so
+/// the design + interaction model is locked in.
+class ActionConfirmationCard extends StatelessWidget {
+  const ActionConfirmationCard({
+    super.key,
+    required this.title,
+    required this.body,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final String body;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.spacing8),
+      padding: const EdgeInsets.all(AppSpacing.spacing12),
+      decoration: BoxDecoration(
+        color: AppColors.primary50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.primary200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: AppTextStyles.body2),
+          const Gap(AppSpacing.spacing4),
+          Text(
+            body,
+            style: AppTextStyles.body4.copyWith(color: AppColors.neutral700),
+          ),
+          const Gap(AppSpacing.spacing12),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onCancel,
+                  child: const Text('Hủy'),
+                ),
+              ),
+              const Gap(AppSpacing.spacing8),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: onConfirm,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary500,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('Xác nhận'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/ai_chat/presentation/riverpod/bexly_agent_service_provider.dart
+++ b/lib/features/ai_chat/presentation/riverpod/bexly_agent_service_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:bexly/features/ai_chat/data/services/bexly_agent_service.dart';
+
+/// Provides a singleton [BexlyAgentService] instance for the AI chat feature.
+///
+/// Consumed by chat UI once [LLMDefaultConfig.useBexlyAgent] is true.
+/// Until Phase 3.1.5 enables the feature flag in dev, the legacy ai-proxy
+/// path in [ChatNotifier] remains the active default.
+final bexlyAgentServiceProvider = Provider<BexlyAgentService>(
+  (ref) => BexlyAgentService(),
+);


### PR DESCRIPTION
## Summary

Phase 3.1 part B (Bexly Flutter side): adds `BexlyAgentService` that streams plain text from the Mastra agent's \`/api/agent/chat\` endpoint, behind a \`BEXLY_USE_AGENT\` feature flag (default off). Includes scaffolded \`ActionConfirmationCard\` widget for the Phase 3.4 structured-event wiring.

Server side (PR A) already merged: DOS/DOS.AI#355 (commit \`cc6a995c\`) - coalescer + Next.js + JWT helper + \`/api/agent/chat\` route.

Persona spec: [docs/superpowers/specs/2026-05-13-bexly-agent-persona-design.md](docs/superpowers/specs/2026-05-13-bexly-agent-persona-design.md)
Implementation plan: [docs/superpowers/plans/2026-05-14-bexly-agent-phase-3-1-mobile-channel.md](docs/superpowers/plans/2026-05-14-bexly-agent-phase-3-1-mobile-channel.md)

## What's in

- **\`BexlyAgentService\`** (\`lib/features/ai_chat/data/services/bexly_agent_service.dart\`) - HTTP+streaming, Supabase JWT auth, throws \`BexlyAgentAuthException\` on 401/403, \`BexlyAgentException\` otherwise.
- **\`bexlyAgentServiceProvider\`** in standalone Riverpod file (avoid touching the 4229-line \`chat_provider.dart\`).
- **\`ActionConfirmationCard\`** widget (\`lib/features/ai_chat/presentation/components/action_confirmation_card.dart\`) - scaffolded only, not yet rendered in chat stream. Phase 3.4 wires it after the server side switches to structured event streaming.
- **\`LlmConfig.useBexlyAgent\`** feature flag via \`String/bool.fromEnvironment('BEXLY_USE_AGENT')\` - default \`false\` so legacy ai-proxy + client-side action parsing stays the default until the agent path is exercised in dev.
- **\`.env.example\`** documents \`BEXLY_USE_AGENT\` + \`BEXLY_AGENT_URL\`.

## What's deferred to follow-up

- **Wiring** \`useBexlyAgent\` into \`ChatNotifier\` to actually swap LLM calls - kept out of this PR to minimize risk on the 4229-line chat module. Will land as a tiny PR once the agent endpoint is exercised in dev with real JWTs.
- **ActionConfirmationCard render** - depends on Phase 3.4 server-side switch to \`fullStream\` + SSE event types.
- **Phase 3.2 Telegram + 3.3 Zalo** - separate plans/PRs.

## Test plan

- [x] \`flutter analyze lib/features/ai_chat/ lib/core/config/\` clean on changed files
- [ ] (controller manual) curl the deployed agent endpoint to sanity check JWT auth flow:
  \`\`\`bash
  curl -N -X POST https://bexly-agent.dos.ai/api/agent/chat \
    -H \"Authorization: Bearer \$JOY_JWT\" -H 'Content-Type: application/json' \
    -d '{\"message\":\"Chào em\"}'
  \`\`\`
- [ ] (later phase) emulator smoke once \`BEXLY_USE_AGENT=true\` wiring lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)