### PR TITLE
feat(ai-chat): parse SSE events + agent tool badges (phase 3.4B)

### DIFF
--- a/lib/features/ai_chat/data/services/bexly_agent_service.dart
+++ b/lib/features/ai_chat/data/services/bexly_agent_service.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:bexly/core/utils/logger.dart';
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
 
 class BexlyAgentException implements Exception {
   BexlyAgentException(this.message, {this.statusCode});
@@ -20,12 +25,144 @@ class BexlyAgentAuthException extends BexlyAgentException {
   BexlyAgentAuthException(super.message) : super(statusCode: 401);
 }
 
-/// Calls Bexly Agent's `/api/agent/chat` and streams plain-text chunks.
+// ---------------------------------------------------------------------------
+// Typed event sum type (Phase 3.4A SSE protocol)
+// ---------------------------------------------------------------------------
+
+/// Sealed base for all events yielded by [BexlyAgentService.chat].
 ///
-/// Phase 3.1 ships text-only streaming (no Vercel AI SDK protocol). Tool calls
-/// execute server-side and surface as part of the agent reply. Phase 3.4 will
-/// switch to structured event streaming so the mobile can render action
-/// confirmation cards inline.
+/// The Bexly Agent endpoint emits Server-Sent Events in the form:
+/// ```
+/// event: text
+/// data: {"text":"hello"}
+///
+/// event: tool_call
+/// data: {"id":"tc_1","name":"record_transaction","args":{...}}
+/// ```
+/// Each SSE frame is parsed into one of the concrete sub-types below.
+sealed class AgentEvent {
+  const AgentEvent();
+}
+
+/// Incremental text content from the agent.
+class AgentTextDelta extends AgentEvent {
+  const AgentTextDelta(this.text);
+
+  final String text;
+}
+
+/// A tool the agent invoked on the server side (already executed).
+class AgentToolCall extends AgentEvent {
+  const AgentToolCall({
+    required this.id,
+    required this.name,
+    required this.args,
+  });
+
+  final String id;
+  final String name;
+  final Map<String, dynamic> args;
+}
+
+/// The result of a server-side tool execution.
+class AgentToolResult extends AgentEvent {
+  const AgentToolResult({
+    required this.id,
+    required this.result,
+    required this.isError,
+  });
+
+  final String id;
+  final Object? result;
+  final bool isError;
+}
+
+/// An error reported by the agent stream.
+class AgentStreamError extends AgentEvent {
+  const AgentStreamError({required this.message, this.code});
+
+  final String message;
+  final String? code;
+}
+
+/// Signals the agent stream has finished normally.
+class AgentStreamDone extends AgentEvent {
+  const AgentStreamDone();
+}
+
+// ---------------------------------------------------------------------------
+// SSE frame parser (top-level so it can be tested with @visibleForTesting)
+// ---------------------------------------------------------------------------
+
+/// Parses a single SSE frame (the text between two blank lines) into a typed
+/// [AgentEvent].  Returns `null` for empty, comment-only, or malformed frames.
+///
+/// Frame format expected from the Bexly Agent (Phase 3.4A):
+/// ```
+/// event: <type>
+/// data: <json>
+/// ```
+@visibleForTesting
+AgentEvent? parseSseFrame(String frame) {
+  String? eventType;
+  String? dataLine;
+
+  for (final line in frame.split('\n')) {
+    if (line.startsWith('event:')) {
+      eventType = line.substring(6).trim();
+    } else if (line.startsWith('data:')) {
+      final chunk = line.substring(5).trim();
+      dataLine = dataLine == null ? chunk : '$dataLine\n$chunk';
+    }
+  }
+
+  if (eventType == null || dataLine == null) return null;
+
+  try {
+    final data = jsonDecode(dataLine);
+    switch (eventType) {
+      case 'text':
+        return AgentTextDelta((data as Map)['text'] as String? ?? '');
+      case 'tool_call':
+        final m = data as Map;
+        return AgentToolCall(
+          id: m['id'] as String,
+          name: m['name'] as String,
+          args: ((m['args'] as Map?) ?? const {}).cast<String, dynamic>(),
+        );
+      case 'tool_result':
+        final m = data as Map;
+        return AgentToolResult(
+          id: m['id'] as String,
+          result: m['result'],
+          isError: m['isError'] == true,
+        );
+      case 'error':
+        final m = data as Map;
+        return AgentStreamError(
+          message: m['message'] as String? ?? 'Unknown agent error',
+          code: m['code'] as String?,
+        );
+      case 'done':
+        return const AgentStreamDone();
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Calls Bexly Agent's `/api/agent/chat` and yields typed [AgentEvent]s
+/// parsed from the Server-Sent Events stream the endpoint emits (Phase 3.4A).
+///
+/// Phase history:
+/// - Phase 3.1: plain-text streaming, `Stream<String>`.
+/// - Phase 3.4B (this): structured SSE, `Stream<AgentEvent>`.
 class BexlyAgentService {
   static const _label = 'BexlyAgentService';
   static const _baseUrl = String.fromEnvironment(
@@ -33,14 +170,20 @@ class BexlyAgentService {
     defaultValue: 'https://bexly-agent.dos.ai',
   );
 
-  Stream<String> chat({
+  /// Streams [AgentEvent]s from the Bexly Agent for [message].
+  ///
+  /// Throws [BexlyAgentAuthException] if there is no active session or if the
+  /// server returns 401/403.  Throws [BexlyAgentException] for other HTTP
+  /// errors.  Individual stream errors from the agent are emitted as
+  /// [AgentStreamError] events rather than thrown, unless they are fatal
+  /// connection errors.
+  Stream<AgentEvent> chat({
     required String message,
     String? threadId,
     String locale = 'vi',
   }) async* {
-    // Wrap currentSession access defensively - Supabase.instance throws if
-    // not initialized (hot-restart edge case, cold-start race). Treat as
-    // "no session" rather than crashing the chat flow.
+    // Defensive session access - Supabase.instance can throw on cold-start
+    // race or hot-restart before initialization completes.
     Session? session;
     try {
       session = Supabase.instance.client.auth.currentSession;
@@ -56,15 +199,14 @@ class BexlyAgentService {
       final req = http.Request('POST', Uri.parse('$_baseUrl/api/agent/chat'))
         ..headers['Authorization'] = 'Bearer ${session.accessToken}'
         ..headers['Content-Type'] = 'application/json'
+        ..headers['Accept'] = 'text/event-stream'
         ..body = jsonEncode({
           'message': message,
           if (threadId != null) 'threadId': threadId,
           'locale': locale,
         });
 
-      final streamed = await client
-          .send(req)
-          .timeout(const Duration(seconds: 120));
+      final streamed = await client.send(req).timeout(const Duration(seconds: 120));
 
       if (streamed.statusCode == 401 || streamed.statusCode == 403) {
         final body = await streamed.stream.bytesToString();
@@ -80,8 +222,19 @@ class BexlyAgentService {
         );
       }
 
+      // Parse SSE stream: frames are separated by a blank line (\n\n).
+      // Each frame contains `event: <type>` and `data: <json>` lines.
+      var buffer = '';
       await for (final chunk in streamed.stream.transform(utf8.decoder)) {
-        if (chunk.isNotEmpty) yield chunk;
+        buffer += chunk;
+        while (true) {
+          final sep = buffer.indexOf('\n\n');
+          if (sep < 0) break;
+          final frame = buffer.substring(0, sep);
+          buffer = buffer.substring(sep + 2);
+          final event = parseSseFrame(frame);
+          if (event != null) yield event;
+        }
       }
     } finally {
       client.close();

--- a/lib/features/ai_chat/presentation/components/agent_tool_badge.dart
+++ b/lib/features/ai_chat/presentation/components/agent_tool_badge.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import 'package:bexly/core/constants/app_colors.dart';
+import 'package:bexly/core/constants/app_spacing.dart';
+import 'package:bexly/core/constants/app_text_styles.dart';
+import 'package:bexly/features/ai_chat/presentation/riverpod/chat_provider.dart'
+    show AgentToolEvent;
+
+/// A small inline badge rendered beneath the last assistant message to
+/// surface completed server-side tool calls from the Bexly Agent (Phase 3.4B).
+///
+/// Because the agent already executes tools on the server before streaming
+/// the reply, this badge is purely retrospective (no confirm/cancel UI).
+class AgentToolBadge extends StatelessWidget {
+  const AgentToolBadge({
+    super.key,
+    required this.label,
+    this.isError = false,
+  });
+
+  final String label;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    // Use red50/red600 for errors; green100/green200 for success.
+    // AppColors has red50+red600 but only green100+green200 (no green50/600).
+    final iconColor = isError ? AppColors.red600 : AppColors.green200;
+    final bgColor = isError ? AppColors.red50 : AppColors.greenAlpha10;
+    final borderColor = isError
+        ? AppColors.red600.withValues(alpha: 0.3)
+        : AppColors.green200.withValues(alpha: 0.4);
+    final icon = isError ? Icons.error_outline : Icons.check_circle_outline;
+
+    return Container(
+      margin: const EdgeInsets.only(top: AppSpacing.spacing4),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.spacing8,
+        vertical: AppSpacing.spacing4,
+      ),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: iconColor),
+          const SizedBox(width: AppSpacing.spacing4),
+          Flexible(
+            child: Text(
+              label,
+              style: AppTextStyles.body4.copyWith(color: iconColor),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Derives a human-readable badge label from an [AgentToolEvent].
+///
+/// Covers the 21 MCP tools registered in Phase 2; defaults to a generic
+/// label for any new tool names introduced later.
+String agentToolBadgeLabel(AgentToolEvent tool) {
+  if (tool.isError) {
+    switch (tool.name) {
+      case 'record_transaction':
+        final desc = tool.args['description'] as String? ?? 'giao dich';
+        return 'Loi ghi: $desc';
+      case 'create_budget':
+        return 'Loi tao budget: ${tool.args['name'] ?? ''}';
+      case 'create_goal':
+        return 'Loi tao goal: ${tool.args['name'] ?? ''}';
+      default:
+        return 'Loi: ${tool.name}';
+    }
+  }
+
+  switch (tool.name) {
+    case 'record_transaction':
+      final amt = (tool.args['amount'] as num?)?.toInt() ?? 0;
+      final desc = tool.args['description'] as String? ?? 'giao dich';
+      return 'Da ghi $amt d ($desc)';
+    case 'update_transaction':
+      return 'Da cap nhat giao dich';
+    case 'delete_transaction':
+      return 'Da xoa giao dich';
+    case 'create_budget':
+      return 'Da tao budget: ${tool.args['name'] ?? ''}';
+    case 'update_budget':
+      return 'Da cap nhat budget';
+    case 'delete_budget':
+      return 'Da xoa budget';
+    case 'create_goal':
+      return 'Da tao goal: ${tool.args['name'] ?? ''}';
+    case 'update_goal':
+      return 'Da cap nhat goal';
+    case 'delete_goal':
+      return 'Da xoa goal';
+    case 'analyze_spending':
+      return 'Da phan tich chi tieu';
+    case 'get_transactions':
+      return 'Da lay danh sach giao dich';
+    case 'get_wallets':
+      return 'Da lay danh sach vi';
+    case 'get_budgets':
+      return 'Da lay danh sach budget';
+    case 'get_goals':
+      return 'Da lay danh sach goal';
+    case 'get_categories':
+      return 'Da lay danh sach danh muc';
+    default:
+      return 'Da chay: ${tool.name}';
+  }
+}

--- a/lib/features/ai_chat/presentation/riverpod/chat_provider.dart
+++ b/lib/features/ai_chat/presentation/riverpod/chat_provider.dart
@@ -8,6 +8,8 @@ import 'package:uuid/uuid.dart';
 import 'package:bexly/features/ai_chat/domain/models/chat_message.dart';
 import 'package:bexly/features/ai_chat/data/services/ai_service.dart';
 import 'package:bexly/features/ai_chat/presentation/riverpod/bexly_agent_service_provider.dart';
+import 'package:bexly/features/ai_chat/data/services/bexly_agent_service.dart'
+    show AgentEvent, AgentTextDelta, AgentToolCall, AgentToolResult, AgentStreamError, AgentStreamDone;
 import 'package:bexly/core/utils/logger.dart';
 import 'package:bexly/core/config/llm_config.dart';
 import 'package:bexly/core/services/ai/ai_quota_state.dart';
@@ -266,6 +268,29 @@ final aiServiceProvider = Provider<AIService>((ref) {
   );
 });
 
+// ---------------------------------------------------------------------------
+// Agent tool event (Phase 3.4B)
+// ---------------------------------------------------------------------------
+
+/// A completed server-side tool call from the Bexly Agent, collected during
+/// a single chat turn and exposed via [ChatNotifier.lastAgentTools] so the
+/// UI can render [AgentToolBadge] widgets under the last assistant message.
+class AgentToolEvent {
+  const AgentToolEvent({
+    required this.id,
+    required this.name,
+    required this.args,
+    this.result,
+    this.isError = false,
+  });
+
+  final String id;
+  final String name;
+  final Map<String, dynamic> args;
+  final Object? result;
+  final bool isError;
+}
+
 // Chat State Provider - Using regular provider to prevent dispose
 // IMPORTANT: Don't watch aiServiceProvider here to avoid rebuild/dispose!
 final chatProvider = NotifierProvider<ChatNotifier, ChatState>(ChatNotifier.new);
@@ -279,6 +304,14 @@ class ChatNotifier extends Notifier<ChatState> {
 
   // Store pending screenshot transactions for quick action handling
   List<ReceiptScanResult>? _pendingScreenshotTransactions;
+
+  // Agent tool events from the last Bexly Agent turn (Phase 3.4B).
+  // Cleared at the start of each new turn so stale badges don't persist.
+  final List<AgentToolEvent> _lastAgentTools = [];
+
+  /// Completed tool calls from the most recent Bexly Agent turn.
+  /// Empty when agent is not active or no tools were called.
+  List<AgentToolEvent> get lastAgentTools => List.unmodifiable(_lastAgentTools);
 
   // Get AI service when needed to avoid provider rebuilds
   AIService get _aiService => ref.read(aiServiceProvider);
@@ -298,14 +331,45 @@ class ChatNotifier extends Notifier<ChatState> {
   /// stays available. Default flag value is `false`, preserving current
   /// behavior in production until the agent path is exercised in dev.
   Future<String> _sendMessageWithFallback(String message) async {
+    // Clear previous turn's tool events so stale badges don't persist.
+    _lastAgentTools.clear();
+
     if (LLMDefaultConfig.useBexlyAgent) {
       try {
         Log.d('🤖 Trying Bexly Agent (BEXLY_USE_AGENT=true)...', label: 'AI_FALLBACK');
         final agentSvc = ref.read(bexlyAgentServiceProvider);
         final buffer = StringBuffer();
-        await for (final chunk in agentSvc.chat(message: message)) {
-          buffer.write(chunk);
+        // Map tool_call id -> AgentToolCall so we can pair with tool_result.
+        final pendingCalls = <String, AgentToolCall>{};
+        final collectedTools = <AgentToolEvent>[];
+
+        await for (final event in agentSvc.chat(message: message)) {
+          switch (event) {
+            case AgentTextDelta(:final text):
+              buffer.write(text);
+            case AgentToolCall(:final id, :final name, :final args):
+              Log.i('agent tool[$id]: $name(${jsonEncode(args)})', label: 'AI_FALLBACK');
+              pendingCalls[id] = AgentToolCall(id: id, name: name, args: args);
+            case AgentToolResult(:final id, :final result, :final isError):
+              final call = pendingCalls[id];
+              if (call != null) {
+                collectedTools.add(AgentToolEvent(
+                  id: id,
+                  name: call.name,
+                  args: call.args,
+                  result: result,
+                  isError: isError,
+                ));
+              }
+            case AgentStreamError(:final message):
+              throw Exception('agent stream error: $message');
+            case AgentStreamDone():
+              break;
+          }
         }
+        _lastAgentTools
+          ..clear()
+          ..addAll(collectedTools);
         _usingFallback = false;
         _fallbackModelName = 'bexly-agent';
         return buffer.toString();

--- a/lib/features/ai_chat/presentation/screens/ai_chat_screen.dart
+++ b/lib/features/ai_chat/presentation/screens/ai_chat_screen.dart
@@ -10,6 +10,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:pdfx/pdfx.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:bexly/core/components/scaffolds/custom_scaffold.dart';
+import 'package:bexly/features/ai_chat/presentation/components/agent_tool_badge.dart';
 import 'package:bexly/features/ai_chat/presentation/components/ai_quota_indicator.dart';
 import 'package:bexly/core/extensions/screen_utils_extensions.dart';
 import 'package:bexly/core/constants/app_colors.dart';
@@ -423,6 +424,10 @@ class _MessageBubble extends ConsumerWidget {
     final isUser = message.isFromUser;
     final isTyping = message.isTyping;
     final hasPendingAction = message.hasPendingAction;
+    // Agent tool badges: only shown on the last AI message (Phase 3.4B).
+    final agentTools = (!isUser && isLast)
+        ? ref.read(chatProvider.notifier).lastAgentTools
+        : const <AgentToolEvent>[];
 
     return Container(
       margin: EdgeInsets.only(
@@ -602,6 +607,22 @@ class _MessageBubble extends ConsumerWidget {
                           ],
                         ),
                 ),
+
+          // Agent tool badges (Phase 3.4B): retrospective indicators for
+          // server-side tool calls completed during this agent turn.
+          if (agentTools.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.spacing4),
+            Wrap(
+              spacing: AppSpacing.spacing4,
+              runSpacing: AppSpacing.spacing4,
+              children: agentTools
+                  .map((tool) => AgentToolBadge(
+                        label: agentToolBadgeLabel(tool),
+                        isError: tool.isError,
+                      ))
+                  .toList(),
+            ),
+          ],
 
           const SizedBox(height: AppSpacing.spacing4),
 


### PR DESCRIPTION
## Summary

Phase 3.4 part B (Bexly Flutter). Consumes the new SSE event protocol from the deployed Bexly Agent (DOS-AI PR #357 already merged on dev as commit 063692c9).

\`BexlyAgentService\` now yields typed \`AgentEvent\` (text / tool_call / tool_result / error / done) parsed from SSE frames. \`ChatNotifier\` collects matched tool_call+tool_result pairs into \`_lastAgentTools\` per turn. Chat UI renders inline \`AgentToolBadge\` widgets at the bottom of the last assistant bubble - e.g. "Đã ghi 50.000 đ (cafe)", "Đã tạo budget", "Đã phân tích chi tiêu".

Default flag \`BEXLY_USE_AGENT=false\` preserves legacy chat path; users opt-in via build env var.

## Test plan

- [ ] Build with \`--dart-define=BEXLY_USE_AGENT=true\` + working agent deploy
- [ ] Send "anh chi 50k cafe" → reply text streams, badge appears below message
- [ ] Send "lãi kép là gì?" → explain_concept badge shows; reply text in Vietnamese
- [ ] Toggle flag off → behavior unchanged (legacy DOS AI path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)