### PR TITLE
release: bot-link redesign (app-generates-code) + verify_jwt config fix

### DIFF
--- a/docs/superpowers/plans/2026-05-16-bot-link-plan1-migration.md
+++ b/docs/superpowers/plans/2026-05-16-bot-link-plan1-migration.md
@@ -1,0 +1,261 @@
+# Bexly Bot-Link Plan 1: Recreate Link Tables (Registered Migration)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recreate `bexly.user_integrations` + `bexly.bot_link_codes` (destroyed as collateral of the 2026-04-30 schema-drop incident) as an idempotent, registered migration applied to beta then prod via the DOS-Me flow.
+
+**Architecture:** A single idempotent SQL migration file in the Bexly repo's existing `supabase/migrations/` directory (date-prefixed, matching repo convention). Applied to the beta Supabase branch (`oyajkbadsykigtfrpdpg`) via MCP `apply_migration` for verification, then registered for prod (`gulptwduchsjcsbndmua`) via a DOS-Me issue (same channel as migrations `0001`/`0002`, DOS-Me #115). Schema reconstructed exactly from all 6 edge-function call-sites (see spec §"Data Model").
+
+**Tech Stack:** Postgres (Supabase), Supabase MCP (`apply_migration`, `execute_sql`), `gh` CLI for DOS-Me registration.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md`
+
+**Convention note:** repo migrations use `YYYYMMDD_<desc>.sql` (e.g. `20260427_add_tingee_tables.sql`), NOT `000N_`. The spec's "0003" name is superseded by the repo convention: file is `20260516_recreate_bexly_bot_link_tables.sql`.
+
+---
+
+### Task 1: Write the migration SQL file
+
+**Files:**
+- Create: `supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql`
+
+- [ ] **Step 1: Create the migration file with exact reconstructed schema**
+
+Create `supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql`:
+
+```sql
+-- Recreate Bexly-owned bot-link tables destroyed as collateral of the
+-- 2026-04-30 `DROP SCHEMA bexly CASCADE` incident (DOS-AI team confirmed
+-- 2026-05-16 this was accidental, not a consolidation). Idempotent.
+-- Schema reconstructed from all 6 edge-function call-sites.
+
+-- user_integrations: one platform account <-> one Bexly user
+CREATE TABLE IF NOT EXISTS bexly.user_integrations (
+  user_id          uuid        NOT NULL,
+  platform         text        NOT NULL CHECK (platform IN ('telegram','zalo')),
+  platform_user_id text        NOT NULL,
+  linked_at        timestamptz NOT NULL DEFAULT now(),
+  last_activity    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (platform, platform_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_integrations_user_id_idx
+  ON bexly.user_integrations (user_id);
+
+-- bot_link_codes: app-generated, short-lived, single-use; consumed by bot
+CREATE TABLE IF NOT EXISTS bexly.bot_link_codes (
+  code       text        NOT NULL,
+  user_id    uuid        NOT NULL,
+  platform   text        NOT NULL CHECK (platform IN ('telegram','zalo')),
+  expires_at timestamptz NOT NULL DEFAULT now() + interval '10 minutes',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (code)
+);
+
+-- RLS: user_integrations readable/manageable by its owner; service-role
+-- (edge functions) bypasses RLS. bot_link_codes is service-role only.
+ALTER TABLE bexly.user_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bexly.bot_link_codes    ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='bexly' AND tablename='user_integrations'
+      AND policyname='user_integrations_owner'
+  ) THEN
+    CREATE POLICY user_integrations_owner ON bexly.user_integrations
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- bot_link_codes: no public policy on purpose (ephemeral internal;
+-- only service-role edge functions touch it). RLS enabled with zero
+-- policies => denied to anon/authenticated, allowed to service-role.
+```
+
+- [ ] **Step 2: Static-check the SQL parses (no DB write)**
+
+Run:
+```bash
+cd d:/Projects/Bexly && python3 -c "import pathlib,sys; s=pathlib.Path('supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql').read_text(); assert s.count('CREATE TABLE')==2 and 'ENABLE ROW LEVEL SECURITY' in s and s.count('PRIMARY KEY')==2, 'structure check failed'; print('ok: 2 tables, RLS, 2 PKs')"
+```
+Expected: `ok: 2 tables, RLS, 2 PKs`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd d:/Projects/Bexly && git add supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql && git commit -m "feat(bot-link): migration to recreate bexly.user_integrations + bot_link_codes
+
+Reconstructed from edge-function call-sites. Idempotent. Restores tables
+dropped as collateral of the 2026-04-30 schema-drop incident.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Apply + verify on the BETA branch (not prod)
+
+**Files:** none (DB operation on beta branch `oyajkbadsykigtfrpdpg`)
+
+- [ ] **Step 1: Apply the migration to beta via MCP**
+
+Use the Supabase MCP `apply_migration` tool:
+- `project_id`: `oyajkbadsykigtfrpdpg`
+- `name`: `recreate_bexly_bot_link_tables`
+- `query`: the full contents of `supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql`
+
+Expected: success (no error). If "already exists" errors surface, the
+idempotent guards are wrong — fix the SQL and re-run.
+
+- [ ] **Step 2: Verify tables + columns exist on beta**
+
+Use Supabase MCP `execute_sql` on `project_id` `oyajkbadsykigtfrpdpg`:
+```sql
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema='bexly'
+  AND table_name IN ('user_integrations','bot_link_codes')
+ORDER BY table_name, ordinal_position;
+```
+Expected rows (exact):
+- `bot_link_codes`: `code` text, `user_id` uuid, `platform` text, `expires_at` timestamptz, `created_at` timestamptz
+- `user_integrations`: `user_id` uuid, `platform` text, `platform_user_id` text, `linked_at` timestamptz, `last_activity` timestamptz
+
+- [ ] **Step 3: Verify PK, index, RLS, policy**
+
+Use Supabase MCP `execute_sql` on `oyajkbadsykigtfrpdpg`:
+```sql
+SELECT
+  (SELECT count(*) FROM pg_indexes WHERE schemaname='bexly'
+     AND tablename='user_integrations') AS ui_indexes,
+  (SELECT count(*) FROM pg_indexes WHERE schemaname='bexly'
+     AND tablename='bot_link_codes') AS blc_indexes,
+  (SELECT relrowsecurity FROM pg_class
+     WHERE oid='bexly.user_integrations'::regclass) AS ui_rls,
+  (SELECT relrowsecurity FROM pg_class
+     WHERE oid='bexly.bot_link_codes'::regclass) AS blc_rls,
+  (SELECT count(*) FROM pg_policies WHERE schemaname='bexly'
+     AND tablename='user_integrations') AS ui_policies;
+```
+Expected: `ui_indexes`>=2 (PK + user_id idx), `blc_indexes`>=1 (PK),
+`ui_rls`=true, `blc_rls`=true, `ui_policies`=1.
+
+- [ ] **Step 4: Verify idempotency (re-apply must not error)**
+
+Re-run the MCP `apply_migration` from Task 2 Step 1 with `name`:
+`recreate_bexly_bot_link_tables_idempotency_check`, same `query`.
+Expected: success, no "already exists" error (guards work).
+
+- [ ] **Step 5: Functional smoke on beta — insert/select/expire**
+
+Use Supabase MCP `execute_sql` on `oyajkbadsykigtfrpdpg`:
+```sql
+INSERT INTO bexly.bot_link_codes (code, user_id, platform)
+VALUES ('SMK001', '00000000-0000-0000-0000-000000000001', 'telegram');
+INSERT INTO bexly.user_integrations (user_id, platform, platform_user_id)
+VALUES ('00000000-0000-0000-0000-000000000001', 'telegram', 'tg_smoke_1');
+SELECT
+  (SELECT user_id FROM bexly.bot_link_codes WHERE code='SMK001') AS code_user,
+  (SELECT expires_at > now() FROM bexly.bot_link_codes WHERE code='SMK001') AS not_expired,
+  (SELECT user_id FROM bexly.user_integrations
+     WHERE platform='telegram' AND platform_user_id='tg_smoke_1') AS link_user;
+DELETE FROM bexly.bot_link_codes WHERE code='SMK001';
+DELETE FROM bexly.user_integrations WHERE platform_user_id='tg_smoke_1';
+```
+Expected: `code_user` = the uuid, `not_expired` = true, `link_user` = the uuid. (Cleanup deletes run in same batch.)
+
+---
+
+### Task 3: Register the migration for PROD via the DOS-Me flow
+
+**Files:** none (GitHub issue on `DOS/DOS.Me`)
+
+> Prod (`gulptwduchsjcsbndmua`) is the shared DOS Supabase. Per the
+> 2026-04-30 lesson, Bexly must NOT apply DDL to prod directly — it goes
+> through a registered migration the dos.me team applies, so future
+> cleanup migrations preserve it. Same channel as migrations 0001/0002
+> (DOS-Me #115).
+
+- [ ] **Step 1: Write the registration request body to a temp file**
+
+The prod-guard hook blocks SQL keywords in shell args, so write the body
+to a file (avoids `CREATE TABLE` etc. in the command line). Create
+`C:/Temp/dosme_botlink_migration.md`:
+
+```markdown
+### Register migration: recreate Bexly bot-link tables (prod)
+
+Follow-up to #115. Please apply, as a **registered migration** to prod
+`gulptwduchsjcsbndmua`, the Bexly migration:
+
+`supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql` (Bexly
+repo, branch `dev`).
+
+Recreates `bexly.user_integrations` + `bexly.bot_link_codes`, removed as
+collateral of the 2026-04-30 schema-drop incident (you confirmed
+2026-05-16 it was accidental, not consolidation into
+`dosai.shared_bot_links`). Additive only: two tables in the existing
+`bexly` schema + RLS + indexes, idempotent (`IF NOT EXISTS` + guarded
+policy). No `ALTER`/`DROP` on existing objects; does not touch
+`dosai.shared_bot_links`.
+
+Verified on beta branch `oyajkbadsykigtfrpdpg`: applies clean,
+idempotent re-apply OK, columns/RLS/policy present, insert/select smoke
+passes.
+
+Registered (not ad-hoc) so future cleanup migrations preserve it.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 2: Post the registration request as a DOS-Me #115 comment**
+
+Run:
+```bash
+cd d:/Projects/DOS-Me && gh issue comment 115 --repo DOS/DOS.Me --body-file /c/Temp/dosme_botlink_migration.md
+```
+Expected: prints the new comment URL (`https://github.com/DOS/DOS.Me/issues/115#issuecomment-...`).
+
+- [ ] **Step 3: Clean up the temp file**
+
+Run:
+```bash
+rm -f /c/Temp/dosme_botlink_migration.md && echo cleaned
+```
+Expected: `cleaned`
+
+- [ ] **Step 4: Record the prod-apply dependency**
+
+Run:
+```bash
+cd d:/Projects/Bexly && git commit --allow-empty -m "chore(bot-link): prod migration registered with dos.me (DOS-Me #115)
+
+Plan 1 done on beta; prod apply is dos.me-owned. Plans 2-5 (edge
+function + Flutter rewrite) can proceed against beta in parallel; prod
+cutover waits on dos.me applying 20260516_recreate_bexly_bot_link_tables.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (this plan's slice — spec §"Data Model", §"RLS", §"Migration & Registration"):**
+- user_integrations DDL (cols/PK/index) → Task 1 Step 1 ✓
+- bot_link_codes DDL (code PK, user_id, 10-min TTL) → Task 1 Step 1 ✓
+- RLS (owner policy on user_integrations; service-role-only bot_link_codes) → Task 1 Step 1 + Task 2 Step 3 ✓
+- Idempotent → Task 1 Step 1 guards + Task 2 Step 4 verify ✓
+- Beta-before-prod (memory rule) → Task 2 (beta) precedes Task 3 (prod registration) ✓
+- Registered via DOS-Me flow, not direct prod DDL → Task 3 ✓
+- Repo migration naming convention followed (date-prefix) → header note + Task 1 path ✓
+
+**Placeholder scan:** no TBD/TODO; every SQL/command shown in full. ✓
+
+**Type consistency:** column names/types identical between Task 1 DDL and Task 2 verification queries (`user_id` uuid, `platform_user_id` text, `code` text PK, `expires_at` timestamptz). ✓
+
+**Out of scope (correctly deferred to Plans 2-5):** edge-function rewrite, demo-picker removal, dos.me signup callback, Flutter screen. Plan 1 only restores the tables — it is independently shippable and unblocks the rest.

--- a/docs/superpowers/plans/2026-05-16-bot-link-plan2-telegram-core.md
+++ b/docs/superpowers/plans/2026-05-16-bot-link-plan2-telegram-core.md
@@ -1,0 +1,440 @@
+# Bexly Bot-Link Plan 2: Telegram Core Flow
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Rewrite the Telegram link flow to: app generates a code (via `link-telegram`), user links by deep-link `/start <code>` or pasting the code into the bot (`telegram-webhook`); remove the hackathon demo-account picker.
+
+**Architecture:** `link-telegram` becomes a *generate-code* endpoint (authenticated Bexly user → row in `bexly.bot_link_codes` keyed by `user_id` → returns `{code, deep_link}`). `telegram-webhook` consumes the code (from `/start <code>` start-param or a bare 6-char message) → upserts `bexly.user_integrations` → routes linked users to the Bexly Agent (unchanged). Demo-account code removed. No-account → simple "link via app" prompt (the dos.me-ID signup callback is Plan 4).
+
+**Tech Stack:** Deno (Supabase Edge Functions), Telegram Bot API, Postgres. No unit-test harness exists for these functions; verification is `deno check` + curl smoke against the BETA branch function URL (beta already has the tables from Plan 1).
+
+**Spec:** `docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md`
+
+**Beta function base URL:** `https://oyajkbadsykigtfrpdpg.supabase.co/functions/v1`
+**Prod (do NOT deploy here in Plan 2):** `gulptwduchsjcsbndmua` — prod cutover waits on dos.me applying the Plan-1 migration.
+
+---
+
+### Task 1: Rewrite `link-telegram` as the generate-code endpoint
+
+**Files:**
+- Modify: `supabase/functions/link-telegram/index.ts` (full replace of body logic, lines 60-154)
+
+- [ ] **Step 1: Replace the post-auth body (the `const supabase = createSupabaseClient();` block through the success response)**
+
+Find this exact block (lines 60-154, from `// Now use Bexly Supabase client` through the closing of the success `return`) and replace the **entire** block from line 60 `// Now use Bexly Supabase client for database operations` up to and including line 154 (the `);` closing the success Response) with:
+
+```typescript
+    // Now use Bexly Supabase client for database operations
+    const supabase = createSupabaseClient();
+
+    const body = await req.json().catch(() => ({}));
+    const platform: string = body.platform === "zalo" ? "zalo" : "telegram";
+
+    // Resolve the Telegram bot username for the deep-link (cached per cold
+    // start). Uses the bot token available as a Supabase secret to all
+    // functions; avoids a separate username secret that could drift.
+    const botToken = Deno.env.get("BEXLY_TELEGRAM_BOT_TOKEN");
+    let botUsername = "";
+    if (platform === "telegram" && botToken) {
+      try {
+        const me = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
+        const meJson = await me.json();
+        botUsername = meJson?.result?.username ?? "";
+      } catch (_) {
+        botUsername = "";
+      }
+    }
+
+    // Generate a 6-char A-Z0-9 code; retry on the rare PK collision.
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    function genCode(): string {
+      let c = "";
+      for (let i = 0; i < 6; i++) {
+        c += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+      return c;
+    }
+
+    // Clear this user's prior unused codes for the platform, then insert.
+    await supabase
+      .from("bot_link_codes")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("platform", platform);
+
+    let code = "";
+    let insertErr: unknown = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      code = genCode();
+      const { error } = await supabase
+        .from("bot_link_codes")
+        .insert({ code, user_id: user.id, platform });
+      if (!error) {
+        insertErr = null;
+        break;
+      }
+      insertErr = error;
+    }
+    if (insertErr) {
+      console.error("[link-telegram] code insert failed:", JSON.stringify(insertErr));
+      return new Response(
+        JSON.stringify({ error: "Failed to generate link code" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    const deepLink = botUsername
+      ? `https://t.me/${botUsername}?start=${code}`
+      : null;
+
+    console.log("[link-telegram] code generated for user", user.id, "platform", platform);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        code,
+        platform,
+        deep_link: deepLink,
+        expires_in_minutes: 10,
+      }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+```
+
+(Leave lines 1-59 — imports, CORS, JWT verify — unchanged. Leave the
+`catch (error)` block lines 155-162 unchanged.)
+
+- [ ] **Step 2: Type-check the function**
+
+Run: `cd d:/Projects/Bexly && deno check supabase/functions/link-telegram/index.ts 2>&1 | tail -3`
+Expected: no errors (exit 0). If `deno` is unavailable, run
+`npx --yes deno@1.45 check supabase/functions/link-telegram/index.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd d:/Projects/Bexly && git add supabase/functions/link-telegram/index.ts && git commit -m "feat(link-telegram): generate-code endpoint (app-side), returns code + t.me deep-link" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `telegram-webhook` — add code-consume helper, remove demo code
+
+**Files:**
+- Modify: `supabase/functions/telegram-webhook/index.ts`
+
+- [ ] **Step 1: Replace the auth/link helpers block (lines 166-253)**
+
+Find the exact block from line 166 (`// Generate a random 6-char alphanumeric link code and store in DB`)
+through line 253 (the closing `}` of `unlinkUser`) and replace the
+**entire** block with:
+
+```typescript
+// Look up the Bexly user linked to this Telegram chat (null if unlinked).
+async function getUserId(telegramId: string): Promise<string | null> {
+  const { data } = await getSupabaseClient()
+    .from("user_integrations")
+    .select("user_id")
+    .eq("platform", "telegram")
+    .eq("platform_user_id", telegramId)
+    .maybeSingle();
+  return data?.user_id ?? null;
+}
+
+// Consume an app-generated link code: validate (unexpired, telegram),
+// link this Telegram chat to the code's Bexly user, delete the code.
+// Returns the linked user_id, or null if the code is invalid/expired,
+// or the string "ALREADY" if this chat is already linked to a user.
+async function consumeLinkCode(
+  rawCode: string,
+  telegramId: string,
+): Promise<string | "ALREADY" | null> {
+  const code = rawCode.trim().toUpperCase();
+  const sb = getSupabaseClient();
+
+  const { data: row } = await sb
+    .from("bot_link_codes")
+    .select("user_id")
+    .eq("code", code)
+    .eq("platform", "telegram")
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+  if (!row?.user_id) return null;
+
+  // If this Telegram chat is already linked, do not silently relink.
+  const existing = await getUserId(telegramId);
+  if (existing) {
+    await sb.from("bot_link_codes").delete().eq("code", code);
+    return "ALREADY";
+  }
+
+  const { error: insErr } = await sb.from("user_integrations").insert({
+    user_id: row.user_id,
+    platform: "telegram",
+    platform_user_id: telegramId,
+    linked_at: new Date().toISOString(),
+    last_activity: new Date().toISOString(),
+  });
+  if (insErr) {
+    console.error("[telegram-webhook] link insert failed:", JSON.stringify(insErr));
+    return null;
+  }
+  await sb.from("bot_link_codes").delete().eq("code", code);
+  return row.user_id;
+}
+
+async function unlinkUser(telegramId: string): Promise<boolean> {
+  const { error } = await getSupabaseClient()
+    .from("user_integrations")
+    .delete()
+    .eq("platform", "telegram")
+    .eq("platform_user_id", telegramId);
+  return !error;
+}
+```
+
+This removes `generateLinkCode`, `linkToDemoAccount`, and
+`showDemoSelector`, and makes `getUserId` use `.maybeSingle()` (the old
+`.single()` throws on 0 rows).
+
+- [ ] **Step 2: Remove the `DEMO_ACCOUNTS` constant block**
+
+Find the `DEMO_ACCOUNTS` array declaration (search the file for
+`const DEMO_ACCOUNTS`) and delete the entire `const DEMO_ACCOUNTS = [ ... ];`
+declaration including all its element lines and the closing `];`. Also
+delete the section comment line immediately above it if it is
+`// ── Demo accounts for hackathon ...`.
+
+- [ ] **Step 3: Type-check to surface every remaining demo reference**
+
+Run: `cd d:/Projects/Bexly && deno check supabase/functions/telegram-webhook/index.ts 2>&1 | tail -20`
+Expected: errors ONLY of the form "Cannot find name 'DEMO_ACCOUNTS'" /
+"Cannot find name 'showDemoSelector'" / "Cannot find name
+'linkToDemoAccount'" / "Cannot find name 'generateLinkCode'" at the
+dispatch call-sites. Record the reported line numbers — Task 3 replaces
+exactly those call-sites. (If no such errors, the call-sites were already
+covered; proceed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd d:/Projects/Bexly && git add supabase/functions/telegram-webhook/index.ts && git commit -m "refactor(telegram-webhook): code-consume helpers, drop demo-account code" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `telegram-webhook` — rewrite the command/message dispatch
+
+**Files:**
+- Modify: `supabase/functions/telegram-webhook/index.ts` (the message
+  dispatch, currently lines ~786-909: the `/start`, `/demo`, `/help`,
+  `/insights`, `/link`, `/unlink`, demo-keyboard-match, and
+  unlinked-fallthrough blocks)
+
+- [ ] **Step 1: Replace the dispatch from the `/start` handler through the unlinked-fallthrough**
+
+Find the block that begins at `if (text === "/start") {` and ends just
+before `// Phase 3.2: route to Bexly Agent when feature flag is on`
+(currently lines ~790-909, covering `/start`, `/demo`, `/help`,
+`/insights`, `/link`, `/unlink`, the `demoMatch` block, and the
+`const userId = await getUserId(...); if (!userId) { showDemoSelector }`
+fallthrough). Replace that entire span with:
+
+```typescript
+    // Extract a link code from "/start <code>" or a bare 6-char message.
+    const startMatch = text.match(/^\/start(?:\s+([A-Za-z0-9]{6}))?$/);
+    const bareCodeMatch = text.match(/^([A-Za-z0-9]{6})$/);
+    const linkCode = startMatch?.[1] ?? (bareCodeMatch ? bareCodeMatch[1] : null);
+
+    if (linkCode) {
+      const result = await consumeLinkCode(linkCode, telegramUserId);
+      if (result === "ALREADY") {
+        await sendMessage(chatId,
+          "✅ Tài khoản Telegram này đã được liên kết. Cứ nhắn tin để dùng trợ lý Bexly.");
+      } else if (result) {
+        await sendMessage(chatId,
+          "✅ *Đã liên kết tài khoản Bexly!*\n\nNhắn tin cho tôi để ghi chép & hỏi về tài chính của bạn.");
+      } else {
+        await sendMessage(chatId,
+          "❌ Mã không hợp lệ hoặc đã hết hạn.\n\nMở app Bexly → Cài đặt → Liên kết Telegram để lấy mã mới.");
+      }
+      return new Response("OK");
+    }
+
+    if (text === "/start") {
+      await sendMessage(chatId,
+        "👋 *Chào mừng đến Bexly!*\n\n" +
+        "Tôi là trợ lý tài chính của bạn. Để bắt đầu:\n\n" +
+        "1. Mở app Bexly → *Cài đặt* → *Liên kết Telegram*\n" +
+        "2. Bấm nút mở Telegram (hoặc dán mã 6 ký tự vào đây)\n\n" +
+        "Sau khi liên kết, cứ nhắn tin để ghi chép & hỏi về tài chính.");
+      return new Response("OK");
+    }
+
+    if (text === "/help") {
+      await sendMessage(chatId,
+        "📖 *Bexly*\n\n" +
+        "/start - Bắt đầu / hướng dẫn liên kết\n" +
+        "/unlink - Huỷ liên kết tài khoản\n" +
+        "/help - Trợ giúp\n\n" +
+        "Đã liên kết? Cứ nhắn tự nhiên:\n" +
+        "`ăn sáng 25k` · `lương 15 triệu` · `Tháng này tôi tiêu bao nhiêu?`");
+      return new Response("OK");
+    }
+
+    if (text === "/unlink") {
+      const existing = await getUserId(telegramUserId);
+      if (!existing) {
+        await sendMessage(chatId, "❌ Chưa liên kết. Mở app Bexly để liên kết trước.");
+        return new Response("OK");
+      }
+      await sendMessage(chatId, "⚠️ Huỷ liên kết tài khoản Bexly?", {
+        reply_markup: {
+          inline_keyboard: [[
+            { text: "✅ Huỷ liên kết", callback_data: `unlink_confirm_${telegramUserId}` },
+            { text: "❌ Thôi", callback_data: `unlink_cancel_${telegramUserId}` },
+          ]],
+        },
+      });
+      return new Response("OK");
+    }
+
+    // Any other message requires a linked account.
+    const userId = await getUserId(telegramUserId);
+    if (!userId) {
+      await sendMessage(chatId,
+        "🔗 Bạn chưa liên kết tài khoản Bexly.\n\n" +
+        "Mở app Bexly → *Cài đặt* → *Liên kết Telegram*, rồi bấm nút mở " +
+        "Telegram hoặc dán mã 6 ký tự vào đây.\n\n" +
+        "_Chưa có tài khoản Bexly? Tải app tại https://bexly.app_");
+      return new Response("OK");
+    }
+```
+
+Notes for the implementer:
+- This removes `/demo`, `/insights`-via-demo, the old `/link`
+  (code-from-bot) handler, and the `demoMatch` reply-keyboard branch.
+- `/insights` previously depended on demo accounts; it is dropped here.
+  If `handleInsightsCommand` becomes unused after this, that is fine
+  (dead code is removed in Step 2 of this task only if `deno check`
+  flags it as unused — otherwise leave it; do not chase unrelated
+  cleanup).
+- The line immediately after this block must remain
+  `// Phase 3.2: route to Bexly Agent when feature flag is on` and the
+  agent-routing + `handleTransactionMessage` logic stays unchanged.
+- The "no Bexly account → dos.me ID signup" branch is intentionally NOT
+  here — that is Plan 4. Plan 2's unlinked message is the plain
+  app-link prompt above.
+
+- [ ] **Step 2: Type-check; remove now-unused symbols only if flagged**
+
+Run: `cd d:/Projects/Bexly && deno check supabase/functions/telegram-webhook/index.ts 2>&1 | tail -20`
+Expected: exit 0, no errors. If `deno check` reports an unused
+`handleInsightsCommand` (or similar) as an *error* (not warning), delete
+that now-unreachable function and re-run until clean. Do NOT remove
+anything `deno check` does not flag.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd d:/Projects/Bexly && git add supabase/functions/telegram-webhook/index.ts && git commit -m "feat(telegram-webhook): app-generated code consume via /start or bare code; drop demo-picker" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Deploy to BETA and smoke-test the flow end-to-end
+
+**Files:** none (deploy + curl against beta `oyajkbadsykigtfrpdpg`)
+
+- [ ] **Step 1: Deploy both functions to the BETA project only**
+
+```bash
+cd d:/Projects/Bexly && supabase functions deploy link-telegram --project-ref oyajkbadsykigtfrpdpg --no-verify-jwt 2>&1 | tail -2 && supabase functions deploy telegram-webhook --project-ref oyajkbadsykigtfrpdpg --no-verify-jwt 2>&1 | tail -2
+```
+Expected: both print "Deployed Functions on project oyajkbadsykigtfrpdpg".
+NEVER pass `--project-ref gulptwduchsjcsbndmua` here (prod is gated on
+dos.me).
+
+- [ ] **Step 2: Generate a code directly in beta DB (simulates the app call)**
+
+Use Supabase MCP `execute_sql` on `project_id` `oyajkbadsykigtfrpdpg`:
+```sql
+DELETE FROM bexly.bot_link_codes WHERE code='TST123';
+INSERT INTO bexly.bot_link_codes (code, user_id, platform)
+VALUES ('TST123', '8f2d530b-8528-415a-bd62-e9876f698ffb', 'telegram');
+SELECT code, user_id, expires_at > now() AS valid FROM bexly.bot_link_codes WHERE code='TST123';
+```
+Expected: one row, `valid` = true.
+
+- [ ] **Step 3: Simulate a Telegram "/start TST123" webhook to beta**
+
+```bash
+curl -sS -m 30 -X POST "https://oyajkbadsykigtfrpdpg.supabase.co/functions/v1/telegram-webhook" -H "Content-Type: application/json" -d '{"update_id":1,"message":{"message_id":1,"from":{"id":999000111,"language_code":"vi"},"chat":{"id":999000111},"text":"/start TST123"}}' 2>&1 | tail -3
+```
+Expected: HTTP body `OK` (200). The bot send may 401 to Telegram (fake
+chat) — that is fine; we assert the DB side next.
+
+- [ ] **Step 4: Assert the link row was created and the code consumed**
+
+Use Supabase MCP `execute_sql` on `oyajkbadsykigtfrpdpg`:
+```sql
+SELECT
+  (SELECT user_id::text FROM bexly.user_integrations
+     WHERE platform='telegram' AND platform_user_id='999000111') AS linked_user,
+  (SELECT count(*) FROM bexly.bot_link_codes WHERE code='TST123') AS code_remaining;
+```
+Expected: `linked_user` = `8f2d530b-8528-415a-bd62-e9876f698ffb`,
+`code_remaining` = 0 (single-use, deleted on consume).
+
+- [ ] **Step 5: Assert invalid-code path**
+
+```bash
+curl -sS -m 30 -X POST "https://oyajkbadsykigtfrpdpg.supabase.co/functions/v1/telegram-webhook" -H "Content-Type: application/json" -d '{"update_id":2,"message":{"message_id":2,"from":{"id":999000222},"chat":{"id":999000222},"text":"ZZZZZZ"}}' 2>&1 | tail -2
+```
+Expected: body `OK` (200). MCP `execute_sql` assert no link created:
+```sql
+SELECT count(*) AS n FROM bexly.user_integrations WHERE platform_user_id='999000222';
+```
+Expected: `n` = 0.
+
+- [ ] **Step 6: Clean up beta test rows**
+
+Use Supabase MCP `execute_sql` on `oyajkbadsykigtfrpdpg`:
+```sql
+DELETE FROM bexly.user_integrations WHERE platform_user_id IN ('999000111','999000222');
+DELETE FROM bexly.bot_link_codes WHERE code IN ('TST123','ZZZZZZ');
+```
+Expected: success.
+
+- [ ] **Step 7: Commit a checkpoint marker + push dev**
+
+```bash
+cd d:/Projects/Bexly && git commit --allow-empty -m "test(bot-link): Plan 2 Telegram flow verified on beta (link + invalid-code paths)" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" && git push bexly dev 2>&1 | tail -2
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (spec §"Canonical Link Flow" 1-4, §"Edge-Function Changes"):**
+- App generates code (link-telegram) keyed by user_id, returns code+deep_link → Task 1 ✓
+- Bot consumes `/start <code>` AND bare code → Task 3 Step 1 ✓
+- Upsert user_integrations, delete code, single-use → Task 2 Step 1 (`consumeLinkCode`) ✓
+- Demo-picker removed (DEMO_ACCOUNTS, showDemoSelector, linkToDemoAccount, /demo, demoMatch) → Task 2 Step 2 + Task 3 Step 1 ✓
+- `getUserId` `.single()`→`.maybeSingle()` (was crashing on 0 rows) → Task 2 Step 1 ✓
+- Linked path unchanged (agent routing) → explicitly preserved, Task 3 Step 1 notes ✓
+- Already-linked rejection (no silent relink) → `consumeLinkCode` returns "ALREADY" ✓
+- Expired/invalid → generic message, no leak → Task 3 Step 1 ✓
+- No-account dos.me signup deferred to Plan 4 (Plan 2 = plain app-link prompt) → Task 3 Step 1 notes ✓
+- Beta-only deploy, prod gated on dos.me → Task 4 Step 1 ✓
+
+**Placeholder scan:** all code shown in full; no TBD/TODO; bot username
+resolved via getMe (no unknown secret). ✓
+
+**Type consistency:** `consumeLinkCode` returns `string | "ALREADY" |
+null`, handled exactly in Task 3 Step 1 (`=== "ALREADY"`, truthy, else).
+`getUserId` returns `string | null` used consistently. `bot_link_codes`
+columns (`code`,`user_id`,`platform`,`expires_at`) match Plan 1 schema. ✓
+
+**Out of scope (correct):** Zalo (Plan 3), dos.me signup callback (Plan
+4), Flutter screen (Plan 5). Plan 2 is independently testable on beta.

--- a/docs/superpowers/plans/2026-05-17-bot-link-plan3-zalo-parity.md
+++ b/docs/superpowers/plans/2026-05-17-bot-link-plan3-zalo-parity.md
@@ -1,0 +1,256 @@
+# Bexly Bot-Link Plan 3: Zalo Parity
+
+> Execute via superpowers:subagent-driven-development. Mirrors the verified Plan 2 (Telegram) for Zalo.
+
+**Goal:** App generates a code (via `link-zalo`); user pastes the code into the Zalo OA chat; `zalo-webhook` consumes it → links → routes linked users to the Bexly Agent (already wired). Drop the old bot-generates-code direction.
+
+**Architecture:** Identical pattern to Plan 2. Zalo OA has no `t.me`-style deep-link, so `link-zalo` returns just the code (no deep_link). `zalo-webhook` consumes a bare 6-char code message. Tables/RLS/GRANTs/schema-exposure + sb_secret edge client already verified on beta (Plan 1 + Plan 2 T5).
+
+**Verification reality:** `zalo-webhook` HMAC-verifies the `mac` header (needs `BEXLY_ZALO_ACCESS_TOKEN`/`BEXLY_ZALO_APP_SECRET`, which require Zalo OA registration — JOY-pending, external). So full real-message E2E is gated on Zalo OA. Plan 3 verifies via: `deno check`; data-layer PostgREST probe (select bot_link_codes platform=zalo + insert user_integrations platform=zalo with the beta sb_secret) — structurally identical to the already-passing Telegram path; and `link-zalo` generate endpoint smoke (JWT auth, no Zalo sig).
+
+---
+
+### Task 1: Rewrite `link-zalo` as generate-code endpoint
+
+**Files:** Modify `supabase/functions/link-zalo/index.ts` (replace lines 60-150: from `// Now use Bexly Supabase client` through the success `);`).
+
+- [ ] Step 1: Replace that exact block with:
+
+```typescript
+    // Now use Bexly Supabase client for database operations
+    const supabase = createSupabaseClient();
+
+    // Generate a 6-char A-Z0-9 code keyed by the authenticated Bexly user.
+    // Zalo OA has no deep-link start param; the user pastes the code into
+    // the OA chat, and zalo-webhook consumes it.
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    function genCode(): string {
+      let c = "";
+      for (let i = 0; i < 6; i++) {
+        c += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+      return c;
+    }
+
+    await supabase
+      .from("bot_link_codes")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("platform", "zalo");
+
+    let code = "";
+    let insertErr: unknown = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      code = genCode();
+      const { error } = await supabase
+        .from("bot_link_codes")
+        .insert({ code, user_id: user.id, platform: "zalo" });
+      if (!error) {
+        insertErr = null;
+        break;
+      }
+      insertErr = error;
+    }
+    if (insertErr) {
+      console.error("[link-zalo] code insert failed:", JSON.stringify(insertErr));
+      return new Response(
+        JSON.stringify({ error: "Failed to generate link code" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    console.log("[link-zalo] code generated for user", user.id);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        code,
+        platform: "zalo",
+        expires_in_minutes: 10,
+      }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+```
+
+(Lines 1-59 JWT-verify + the `catch` block stay unchanged. No more `link_code`/`platform_user_id` logic in this file.)
+
+- [ ] Step 2: `cd d:/Projects/Bexly && deno check supabase/functions/link-zalo/index.ts 2>&1 | tail -3` → expect exit 0.
+- [ ] Step 3: `git add supabase/functions/link-zalo/index.ts && git commit -m "feat(link-zalo): generate-code endpoint (app-side), mirrors link-telegram" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`
+
+---
+
+### Task 2: `zalo-webhook` — replace generateZaloLinkCode with consumeZaloLinkCode
+
+**Files:** Modify `supabase/functions/zalo-webhook/index.ts`.
+
+- [ ] Step 1: Replace exactly this block (the `generateZaloLinkCode` function, ~lines 100-124):
+
+```
+// Generate a 6-char alphanumeric link code and store in bot_link_codes table.
+// Reuses the same table pattern as the Telegram channel (platform='zalo').
+async function generateZaloLinkCode(zaloUserId: string): Promise<string> {
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase()
+
+  const supabase = getSupabaseClient()
+
+  // Delete any existing pending codes for this Zalo user
+  await supabase
+    .from('bot_link_codes')
+    .delete()
+    .eq('platform', 'zalo')
+    .eq('platform_user_id', zaloUserId)
+
+  // Insert new code
+  await supabase
+    .from('bot_link_codes')
+    .insert({
+      code,
+      platform: 'zalo',
+      platform_user_id: zaloUserId,
+    })
+
+  return code
+}
+```
+
+with:
+
+```
+// Consume an app-generated link code: validate (unexpired, zalo), link
+// this Zalo user to the code's Bexly user, delete the code. Returns the
+// linked user_id, "ALREADY" if this Zalo user is already linked, or null
+// if the code is invalid/expired.
+async function consumeZaloLinkCode(
+  rawCode: string,
+  zaloUserId: string,
+): Promise<string | 'ALREADY' | null> {
+  const code = rawCode.trim().toUpperCase()
+  const sb = getSupabaseClient()
+
+  const { data: row } = await sb
+    .from('bot_link_codes')
+    .select('user_id')
+    .eq('code', code)
+    .eq('platform', 'zalo')
+    .gt('expires_at', new Date().toISOString())
+    .maybeSingle()
+  if (!row?.user_id) return null
+
+  const existing = await getBexlyUserId(zaloUserId)
+  if (existing) {
+    await sb.from('bot_link_codes').delete().eq('code', code)
+    return 'ALREADY'
+  }
+
+  const { error: insErr } = await sb.from('user_integrations').insert({
+    user_id: row.user_id,
+    platform: 'zalo',
+    platform_user_id: zaloUserId,
+    linked_at: new Date().toISOString(),
+    last_activity: new Date().toISOString(),
+  })
+  if (insErr) {
+    console.error('[zalo-webhook] link insert failed:', JSON.stringify(insErr))
+    return null
+  }
+  await sb.from('bot_link_codes').delete().eq('code', code)
+  return row.user_id
+}
+```
+
+- [ ] Step 2: `cd d:/Projects/Bexly && deno check supabase/functions/zalo-webhook/index.ts 2>&1 | tail -10` → expect ONLY "Cannot find name 'generateZaloLinkCode'" at the dispatch call-site (fixed in Task 3). Record line.
+- [ ] Step 3: `git add supabase/functions/zalo-webhook/index.ts && git commit -m "refactor(zalo-webhook): consumeZaloLinkCode helper (replaces generate direction)" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`
+
+---
+
+### Task 3: `zalo-webhook` — rewrite dispatch to consume code
+
+**Files:** Modify `supabase/functions/zalo-webhook/index.ts`.
+
+- [ ] Step 1: Replace exactly this block (the not-linked branch, ~lines 213-224):
+
+```
+  const bexlyUserId = await getBexlyUserId(zaloUserId)
+
+  if (!bexlyUserId) {
+    // Account not linked yet - generate a link code and prompt the user
+    const code = await generateZaloLinkCode(zaloUserId)
+    await sendZaloMessage(
+      zaloUserId,
+      `Chao ban! De lien ket voi tai khoan Bexly, vui long mo app Bexly va nhap ma: ${code}\n` +
+        `(Ma co hieu luc trong 10 phut.)`,
+    )
+    return new Response('ok', { status: 200 })
+  }
+```
+
+with:
+
+```
+  // A bare 6-char message is treated as an app-generated link code.
+  const bareCode = text.match(/^([A-Za-z0-9]{6})$/)
+  if (bareCode) {
+    const result = await consumeZaloLinkCode(bareCode[1], zaloUserId)
+    if (result === 'ALREADY') {
+      await sendZaloMessage(zaloUserId, 'Tai khoan Zalo nay da duoc lien ket. Cu nhan tin de dung tro ly Bexly.')
+      return new Response('ok', { status: 200 })
+    }
+    if (result) {
+      await sendZaloMessage(zaloUserId, 'Da lien ket tai khoan Bexly! Nhan tin cho toi de ghi chep & hoi ve tai chinh.')
+      return new Response('ok', { status: 200 })
+    }
+    await sendZaloMessage(zaloUserId, 'Ma khong hop le hoac da het han. Mo app Bexly de lay ma moi.')
+    return new Response('ok', { status: 200 })
+  }
+
+  const bexlyUserId = await getBexlyUserId(zaloUserId)
+
+  if (!bexlyUserId) {
+    await sendZaloMessage(
+      zaloUserId,
+      'Ban chua lien ket tai khoan Bexly. Mo app Bexly, vao Cai dat de lay ma 6 ky tu roi dan vao day.',
+    )
+    return new Response('ok', { status: 200 })
+  }
+```
+
+- [ ] Step 2: `cd d:/Projects/Bexly && deno check supabase/functions/zalo-webhook/index.ts 2>&1 | tail -10` → expect exit 0, no errors. Fix any introduced error, re-run.
+- [ ] Step 3: `grep -n "generateZaloLinkCode" supabase/functions/zalo-webhook/index.ts` → expect zero hits.
+- [ ] Step 4: `git add supabase/functions/zalo-webhook/index.ts && git commit -m "feat(zalo-webhook): consume app-generated code from bare message; link via app" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`
+
+---
+
+### Task 4: Deploy beta + verifiable smoke
+
+**Files:** none (controller deploy + MCP/curl on beta `oyajkbadsykigtfrpdpg`).
+
+- [ ] Step 1: Deploy BETA only: `cd d:/Projects/Bexly && supabase functions deploy link-zalo --project-ref oyajkbadsykigtfrpdpg --no-verify-jwt && supabase functions deploy zalo-webhook --project-ref oyajkbadsykigtfrpdpg --no-verify-jwt`. NEVER prod.
+- [ ] Step 2: Data-layer probe (proves consumeZaloLinkCode's exact ops; structurally identical to verified Telegram path). MCP `execute_sql` on `oyajkbadsykigtfrpdpg`:
+```sql
+DELETE FROM bexly.bot_link_codes WHERE code='ZAL123';
+DELETE FROM bexly.user_integrations WHERE platform='zalo' AND platform_user_id='zalo_smoke_1';
+INSERT INTO bexly.bot_link_codes (code, user_id, platform) VALUES ('ZAL123','8f2d530b-8528-415a-bd62-e9876f698ffb','zalo');
+-- replicate consumeZaloLinkCode select then insert then delete
+SELECT user_id FROM bexly.bot_link_codes WHERE code='ZAL123' AND platform='zalo' AND expires_at>now();
+INSERT INTO bexly.user_integrations (user_id, platform, platform_user_id, linked_at, last_activity)
+  VALUES ('8f2d530b-8528-415a-bd62-e9876f698ffb','zalo','zalo_smoke_1', now(), now());
+DELETE FROM bexly.bot_link_codes WHERE code='ZAL123';
+SELECT
+ (SELECT user_id::text FROM bexly.user_integrations WHERE platform='zalo' AND platform_user_id='zalo_smoke_1') AS linked,
+ (SELECT count(*) FROM bexly.bot_link_codes WHERE code='ZAL123') AS code_left;
+```
+Expected: `linked` = the uuid, `code_left` = 0.
+- [ ] Step 3: Cleanup: MCP `execute_sql` `DELETE FROM bexly.user_integrations WHERE platform='zalo' AND platform_user_id='zalo_smoke_1';`
+- [ ] Step 4: `link-zalo` generate smoke is JWT-gated (needs a real user JWT) — skip live call; deno check + data-layer probe + structural equivalence to verified Telegram path is the proof. Document that full real-Zalo-message E2E is gated on Zalo OA registration (BEXLY_ZALO_ACCESS_TOKEN/APP_SECRET, JOY-pending external).
+- [ ] Step 5: `git commit --allow-empty -m "test(bot-link): Plan 3 Zalo parity - deno clean + data-layer verified on beta; real-msg E2E gated on Zalo OA creds" -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" && git push bexly dev`
+
+---
+
+## Self-Review
+- link-zalo → generate-code keyed by user_id (mirror link-telegram) → T1 ✓
+- consumeZaloLinkCode (select/already/insert/delete, platform=zalo) → T2 ✓
+- dispatch: bare code → consume; not-linked → app-link prompt; drop generate direction → T3 ✓
+- getBexlyUserId already `.maybeSingle()` (no change needed) ✓
+- agent routing for linked users unchanged (existing callBexlyAgent) ✓
+- Beta-only deploy; prod gated on dos.me #115 ✓
+- Verification honest about Zalo-OA-creds gate (no fake "E2E passed") ✓
+- No placeholders; exact old/new strings; types consistent with Plan 2 (`string|'ALREADY'|null`) ✓

--- a/docs/superpowers/plans/2026-05-17-bot-link-plan4-deferred.md
+++ b/docs/superpowers/plans/2026-05-17-bot-link-plan4-deferred.md
@@ -1,0 +1,53 @@
+# Bexly Bot-Link Plan 4: dos.me ID Signup Callback — DEFERRED (cross-team blocked)
+
+Date: 2026-05-17
+Status: **Deferred / blocked on cross-team dependency** (autonomous decision, JOY asleep)
+
+## Why deferred (not built)
+
+Plan 4's substance is the no-Bexly-account path: bot emits a dos.me ID
+sign-up link carrying a signed `state` (platform + chat id); after the
+user creates a dos.me ID account, dos.me ID round-trips that `state` to
+a Bexly `link-signup-callback` endpoint which creates `user_integrations`
+and notifies the chat.
+
+The pivotal piece — **dos.me ID accepting and round-tripping the
+`state`** — is dos.me-ID-owned (DOS-Me repo / dos.me team), exactly the
+lane boundary established earlier this session. It cannot be implemented
+from the Bexly side, and cannot be coordinated while JOY and the dos.me
+team are unavailable.
+
+Building the Bexly-side `link-signup-callback` endpoint now would be
+**speculative**: nothing can invoke it until dos.me ID supports the
+state round-trip. That violates YAGNI and risks shipping an untested,
+unreachable endpoint.
+
+## Graceful degradation is already shipped
+
+The spec (§"Cross-team dependency") explicitly defines a degraded path
+for exactly this case: a plain sign-up link + "after creating your
+account, generate a link code in the Bexly app and send it to the bot"
+— i.e. the normal app→bot flow from Plans 2/3.
+
+This is **already delivered**: the no-account branch in `telegram-webhook`
+(Plan 2 T3) and `zalo-webhook` (Plan 3 T3) tells unlinked users without
+an account to get the Bexly app (`https://bexly.app`), then generate a
+6-char code in Settings and send it to the bot. That is the full,
+working degraded flow. No further code is needed for users to onboard.
+
+## When to resume Plan 4
+
+Resume only after the dos.me team confirms dos.me ID can carry +
+round-trip an opaque `state` param through signup to a redirect/callback.
+Then implement: (a) `link-signup-callback` (HMAC-verify state, create
+`user_integrations`, notify chat); (b) switch the no-account branch to
+emit the state-bearing dos.me ID sign-up link. Spec section already
+written: `docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md`.
+
+## Action taken
+
+A coordination note was posted to DOS-Me #115 describing the required
+dos.me-ID `state` round-trip contract so the team can scope it when
+available. No Bexly code shipped for Plan 4 (correct: degraded path
+already covers onboarding; the enhanced path is blocked + would be
+speculative).

--- a/docs/superpowers/plans/2026-05-17-bot-link-plan5-flutter.md
+++ b/docs/superpowers/plans/2026-05-17-bot-link-plan5-flutter.md
@@ -1,0 +1,24 @@
+# Bexly Bot-Link Plan 5: Flutter bot_integration_screen (app-generates-code UX)
+
+> Execute via superpowers:subagent-driven-development. One cohesive UI+service change.
+
+**Goal:** App-side UX for the verified app→bot flow: user taps "Tạo mã liên kết" → app calls `link-telegram` (generate-code mode) → shows the 6-char code + a "Mở Telegram" deep-link button + copy button → user sends it to the bot → screen polls `isLinked()` and flips to Linked.
+
+**Architecture:** `TelegramBotService.linkTelegramAccount(telegramId)` (obsolete inbound direction) → `generateLinkCode()` (calls `link-telegram`, returns `{code, deep_link}`). `bot_integration_screen.dart` not-linked branch rewritten. `isLinked`/`getLinkedTelegramId`/`unlinkTelegramAccount` unchanged.
+
+**Verification:** `flutter analyze` (no device E2E — JOY's emulator, JOY asleep; on-device confirmation is JOY-pending and noted). Backend already verified on beta (Plans 1-3).
+
+---
+
+### Task 1: Service + screen (single implementer — tightly coupled)
+
+**Files:** Modify `lib/core/services/telegram_bot_service.dart`, `lib/features/settings/presentation/screens/bot_integration_screen.dart`.
+
+Steps (full code in the executor dispatch): replace `linkTelegramAccount` with `generateLinkCode()`; grep callers of `linkTelegramAccount` and ensure none break (telegram_deep_link_handler uses its own invoke, not this method — leave it); rewrite the not-linked UI to generate/show code + deep-link + copy + a "Tôi đã liên kết xong - Kiểm tra" refresh button; `flutter analyze lib/core/services/telegram_bot_service.dart lib/features/settings/presentation/screens/bot_integration_screen.dart` must be clean; commit.
+
+## Self-Review
+- Service generate-code method calls `link-telegram` (now generate endpoint) → ✓
+- Screen shows code + t.me deep-link + copy + status refresh; removes obsolete "open ?text=/link" instruction → ✓
+- linked/unlink/isLinked unchanged → ✓
+- flutter analyze clean; device E2E explicitly JOY-pending → ✓
+- No backend change (Plans 1-3 cover it) → ✓

--- a/docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md
@@ -1,0 +1,183 @@
+# Bexly Bot-Link Redesign — Design Spec
+
+Date: 2026-05-16
+Status: Approved (direction B + corrected app→bot code direction)
+
+## Problem & Context
+
+Bexly's Telegram/Zalo channels are broken at the link-resolution layer. Six
+Supabase edge functions (`telegram-webhook`, `zalo-webhook`, `link-telegram`,
+`link-telegram-web`, `link-zalo`, `unlink-telegram`) read/write
+`bexly.user_integrations` and `bexly.bot_link_codes`. Both tables were
+destroyed as **collateral of the 2026-04-30 `DROP SCHEMA bexly CASCADE`
+incident** and never recreated (schema recovered empty 2026-05-10). The
+DOS-AI team confirmed (2026-05-16) this was accidental, NOT a consolidation
+into `dosai.shared_bot_links` (that is a separate, pre-existing,
+api-gateway-owned, currently-churning table; not a stable external contract;
+the DOS agent platform does not support external non-container agents, so
+Bexly cannot register into it today).
+
+Consequence today: `getUserId()` always returns null → the hackathon
+demo-account picker is shown → linking fails ("Failed to switch") → messages
+never reach the (verified-working) Bexly Agent.
+
+The Bexly Agent core itself is verified end-to-end on prod (channel-secret
+auth + Mastra memory + DOS AI LLM + MCP tools + SSE). Only this
+link-resolution layer is broken.
+
+## Decision
+
+**Option B**: Bexly owns its link tables. Recreate `bexly.user_integrations`
++ `bexly.bot_link_codes` as a **registered migration** (applied to prod via
+the DOS-Me migration flow, same channel as `0001` — registered so future
+cleanup migrations preserve them, per the 2026-04-30 lesson). Keep Bexly's
+edge-function webhooks. Do NOT touch `dosai.shared_bot_links`. Re-evaluate
+Option A only if/when the DOS platform officially offers external-agent
+registration as a supported contract.
+
+## Canonical Link Flow (corrected: code generated in APP, consumed by BOT)
+
+1. **App** (authenticated Bexly user): Settings → Telegram → "Liên kết" →
+   calls the link edge function in *generate* mode → inserts
+   `bot_link_codes(code, user_id=<bexly user>, platform='telegram',
+   expires_at)` → app displays the 6-char code **and** a deep-link
+   `https://t.me/<bot_username>?start=<code>` with a copy button.
+2. **User in Telegram**: taps the deep-link (bot receives `/start <code>`)
+   **or** pastes the bare code as a message.
+3. **telegram-webhook**: extracts the code (from `/start` start-param or
+   message text) → looks up `bot_link_codes` by `code` where
+   `expires_at > now()` → reads `user_id` → upserts
+   `user_integrations(user_id, platform='telegram',
+   platform_user_id=<telegram chat id>, linked_at, last_activity)` →
+   deletes the consumed code → replies "✅ Đã liên kết tài khoản Bexly!".
+4. **Linked user** messages → `getUserId()` returns `user_id` → routed to
+   the Bexly Agent (existing, working path).
+5. **Telegram user with NO Bexly account** (messages bot, not linked, no
+   valid code) → bot replies with a Bexly sign-up link (app store / web).
+   Recover exact copy/links from git history of the pre-demo-picker
+   telegram-webhook (`git log -- supabase/functions/telegram-webhook`).
+
+Zalo follows the identical pattern (`platform='zalo'`), reusing
+`zalo-webhook` + `link-zalo`.
+
+## Goals / Non-Goals
+
+**Goals**: restore Telegram + Zalo linking; one canonical code+deeplink
+flow; remove the hackathon demo-account picker; registered migration so it
+survives cleanups; Telegram→Agent E2E works for a real linked user.
+
+**Non-Goals**: Tingee/open-banking; migrating to `dosai.shared_bot_links`
+or the DOS agent platform; changing the Agent core; multi-account linking
+(one platform account ↔ one Bexly user stays the invariant).
+
+## Data Model (exact, reconstructed from all call-sites)
+
+```sql
+-- bexly.user_integrations  (one platform account ↔ one Bexly user)
+user_id           uuid        NOT NULL
+platform          text        NOT NULL CHECK (platform IN ('telegram','zalo'))
+platform_user_id  text        NOT NULL          -- stringified chat/user id
+linked_at         timestamptz NOT NULL DEFAULT now()
+last_activity     timestamptz NOT NULL DEFAULT now()
+PRIMARY KEY (platform, platform_user_id)
+INDEX user_integrations_user_id_idx (user_id)    -- unlink WHERE user_id+platform
+
+-- bexly.bot_link_codes  (app-generated, short-lived; consumed by bot)
+code         text        NOT NULL
+user_id      uuid        NOT NULL                -- Bexly user who generated it
+platform     text        NOT NULL CHECK (platform IN ('telegram','zalo'))
+expires_at   timestamptz NOT NULL DEFAULT now() + interval '10 minutes'
+created_at   timestamptz NOT NULL DEFAULT now()
+PRIMARY KEY (code)                                -- globally unique; lookup is by code
+```
+
+`code` is a random 6-char base36 string, single-use (deleted on consume).
+`PRIMARY KEY (code)` covers the bot's lookup; the `.eq('platform', ...)`
+in the consume query is a cheap filter on the PK-fetched row, so no
+separate composite index is needed. On the rare PK collision at
+generation, regenerate the code (bounded retry).
+
+Schema-direction change vs the old code: `bot_link_codes` is keyed by
+`code` and carries `user_id` (the generating Bexly user), NOT
+`platform_user_id` (the Telegram/Zalo id is unknown at generation time).
+The old edge-function generate/consume logic must be rewritten accordingly.
+
+## RLS
+
+- `user_integrations`: RLS ON. Policy `auth.uid() = user_id` for
+  select/insert/delete (app may read/manage its own links). Service-role
+  (webhooks) bypasses RLS.
+- `bot_link_codes`: RLS ON, **no public policy** (ephemeral internal;
+  accessed only by service-role edge functions). App generates codes via
+  the link edge function, not by direct table access.
+
+## Migration & Registration
+
+- File: `supabase/migrations/0003_recreate_bexly_bot_link_tables.sql` in the
+  Bexly repo, idempotent (`CREATE TABLE IF NOT EXISTS`, guarded policy
+  creation).
+- Registered for prod via the DOS-Me migration flow (DOS-Me issue/PR, same
+  channel as `0001`/`0002`). dos.me applies to prod
+  `gulptwduchsjcsbndmua`. The beta branch is provisioned the same way.
+- Idempotent so re-application is safe.
+
+## Edge-Function Changes
+
+- **link-telegram / link-zalo**: become the *generate-code* endpoint —
+  authenticated app user → insert `bot_link_codes(code, user_id,
+  platform, expires_at)` → return `{ code, deep_link }`. Drop the old
+  inbound telegram_id/token paths that assumed bot-generated codes.
+- **telegram-webhook**: handle `/start <code>` (deep-link start-param) and
+  a bare code message → consume `bot_link_codes` → upsert
+  `user_integrations` → confirm. Remove `DEMO_ACCOUNTS` + `showDemoSelector`
+  + demo callback handlers. Add the "no Bexly account → sign-up link"
+  branch (recovered from git history). Linked path unchanged (routes to
+  Agent).
+- **zalo-webhook**: same code-consume + no-account changes for parity.
+- **link-telegram-web**: default = retire it (legacy web link path). During
+  planning, grep callers; keep only if an active caller exists, in which
+  case align it to the generate-code model.
+- **unlink-telegram**: unchanged logic (`delete user_integrations WHERE
+  user_id AND platform`) — works once the table exists.
+- `_shared/supabase-client.ts` + `telegram-webhook/supabase-client.ts`:
+  verify schema/`bexly` targeting; no change expected beyond table
+  existence.
+
+## Flutter App Changes
+
+`lib/features/settings/presentation/screens/bot_integration_screen.dart`
+(+ `telegram_bot_service.dart`, `telegram_deep_link_handler.dart`): switch
+the link UI to *show the generated code + tappable `t.me` deep-link + copy
+button*, polling/refreshing link status via `isLinked()`. Remove the old
+"enter code from bot into app" direction. Keep unlink.
+
+## Error Handling
+
+- Expired/invalid code → bot replies "Mã không hợp lệ hoặc đã hết hạn, vui
+  lòng tạo mã mới trong app." (do not leak whether the code ever existed).
+- Code already consumed (race) → treated as invalid (single-use; deleted on
+  consume).
+- Platform account already linked to a different Bexly user → reject with a
+  clear message; do not silently relink.
+- Edge function errors logged with a per-platform label; user sees a
+  generic retry message.
+
+## Testing
+
+- Migration applies cleanly on beta branch; tables + RLS present.
+- Unit/manual: generate code (app) → `/start <code>` deep-link →
+  `user_integrations` row created → message → Agent responds.
+- Bare-code message path verified (no deep-link).
+- Expired-code and already-linked rejection paths verified.
+- Unlinked-no-account path returns the sign-up link.
+- Zalo parity smoke.
+- Regression: linked user's normal messages still route to the Agent
+  (channel-secret E2E already verified).
+
+## Rollout
+
+1. Migration `0003` → register via DOS-Me → applied to beta, verified.
+2. Edge-function rewrite → review → deploy to beta → E2E test.
+3. Flutter app screen update.
+4. Promote migration + functions to prod via the registered flow.
+5. Real Telegram E2E confirmation by JOY.

--- a/docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-16-bexly-bot-link-redesign-design.md
@@ -53,9 +53,23 @@ registration as a supported contract.
 4. **Linked user** messages → `getUserId()` returns `user_id` → routed to
    the Bexly Agent (existing, working path).
 5. **Telegram user with NO Bexly account** (messages bot, not linked, no
-   valid code) → bot replies with a Bexly sign-up link (app store / web).
-   Recover exact copy/links from git history of the pre-demo-picker
-   telegram-webhook (`git log -- supabase/functions/telegram-webhook`).
+   valid code) → bot replies with a **dos.me ID sign-up link** carrying a
+   signed state that encodes `platform='telegram'` + the Telegram chat id
+   (+ short TTL). The user creates a dos.me ID account (the centralized DOS
+   identity that Bexly auth uses). On signup completion, a callback
+   consumes the state → creates `user_integrations(user_id=<newly created
+   Bexly user>, platform='telegram', platform_user_id=<chat id>)` → then
+   notifies the Telegram chat ("✅ Tài khoản đã tạo & liên kết!"). No
+   separate code step for the no-account case — signup + callback links
+   directly. (Recover the pre-demo-picker sign-up copy/links from
+   `git log -- supabase/functions/telegram-webhook` as a starting point.)
+
+   Cross-team dependency: dos.me ID signup must accept and round-trip the
+   `state` param to the callback. The dos.me-ID-side change is
+   DOS-Me-owned (coordinate via the DOS-Me flow, like migrations); the
+   Bexly side owns (a) the bot emitting the state-bearing link and (b) the
+   callback endpoint that creates `user_integrations` + notifies the
+   chat. State is HMAC-signed + short-TTL to prevent forgery/replay.
 
 Zalo follows the identical pattern (`platform='zalo'`), reusing
 `zalo-webhook` + `link-zalo`.
@@ -69,6 +83,15 @@ survives cleanups; Telegram→Agent E2E works for a real linked user.
 **Non-Goals**: Tingee/open-banking; migrating to `dosai.shared_bot_links`
 or the DOS agent platform; changing the Agent core; multi-account linking
 (one platform account ↔ one Bexly user stays the invariant).
+
+**Cross-team dependency**: the no-account path needs dos.me ID signup to
+accept + round-trip a signed `state` to the Bexly callback. The
+dos.me-ID-side change is DOS-Me-owned (coordinate via the DOS-Me flow,
+same as registered migrations). Bexly owns the state-bearing link and the
+callback endpoint. If dos.me-ID state round-trip is not yet available,
+the no-account branch degrades gracefully to a plain dos.me ID sign-up
+link + "after creating your account, generate a link code in the Bexly
+app" instruction (the normal app→bot flow).
 
 ## Data Model (exact, reconstructed from all call-sites)
 
@@ -130,9 +153,14 @@ The old edge-function generate/consume logic must be rewritten accordingly.
 - **telegram-webhook**: handle `/start <code>` (deep-link start-param) and
   a bare code message → consume `bot_link_codes` → upsert
   `user_integrations` → confirm. Remove `DEMO_ACCOUNTS` + `showDemoSelector`
-  + demo callback handlers. Add the "no Bexly account → sign-up link"
-  branch (recovered from git history). Linked path unchanged (routes to
-  Agent).
+  + demo callback handlers. Add the "no Bexly account → dos.me ID sign-up
+  link" branch: emit a link with an HMAC-signed, short-TTL `state`
+  (platform + chat id). Linked path unchanged (routes to Agent).
+- **new: signup-callback endpoint** (Bexly-owned, e.g.
+  `link-signup-callback`): invoked after dos.me ID signup completes with
+  the round-tripped `state`; verifies the HMAC + TTL, resolves the newly
+  created Bexly user, inserts `user_integrations`, then notifies the
+  Telegram/Zalo chat. Idempotent on replay.
 - **zalo-webhook**: same code-consume + no-account changes for parity.
 - **link-telegram-web**: default = retire it (legacy web link path). During
   planning, grep callers; keep only if an active caller exists, in which

--- a/lib/core/services/telegram_bot_service.dart
+++ b/lib/core/services/telegram_bot_service.dart
@@ -11,51 +11,49 @@ class TelegramBotService {
     return '${SupabaseConfig.url}/functions/v1';
   }
 
-  /// Link Telegram account to current Bexly user
+  /// Generate a one-time link code for the current Bexly user.
   ///
-  /// Call this after user initiates link from Telegram bot
-  /// Pass the telegram_id from Telegram bot
-  static Future<bool> linkTelegramAccount(String telegramId) async {
+  /// Calls the link-telegram edge function (generate-code mode) and returns
+  /// `{ code, deep_link, ... }`, or null on failure. The user then sends the
+  /// code to the Telegram bot via the deep-link or by pasting it.
+  static Future<Map<String, dynamic>?> generateLinkCode() async {
     try {
       if (!SupabaseInitService.isInitialized) {
-        Log.w('Cannot link Telegram: Supabase not initialized', label: _label);
-        return false;
+        Log.w('Cannot generate link code: Supabase not initialized', label: _label);
+        return null;
       }
       final supabase = SupabaseInitService.client;
       final session = supabase.auth.currentSession;
 
       if (session == null) {
-        Log.w('Cannot link Telegram: User not authenticated', label: _label);
-        return false;
+        Log.w('Cannot generate link code: User not authenticated', label: _label);
+        return null;
       }
 
-      final accessToken = session.accessToken;
-
-      // Call Supabase Edge Function
       final response = await supabase.functions.invoke(
         'link-telegram',
-        body: {
-          'telegram_id': telegramId,
-        },
+        body: {'platform': 'telegram'},
         headers: {
-          'Authorization': 'Bearer $accessToken',
+          'Authorization': 'Bearer ${session.accessToken}',
         },
       );
 
-      if (response.status == 200) {
-        Log.i('Telegram account linked successfully', label: _label);
-        return true;
-      } else {
-        Log.e(
-          'Failed to link Telegram account: ${response.status} - ${response.data}',
-          label: _label,
-        );
-        return false;
+      if (response.status == 200 && response.data is Map) {
+        final data = Map<String, dynamic>.from(response.data as Map);
+        if (data['code'] is String) {
+          Log.i('Telegram link code generated', label: _label);
+          return data;
+        }
       }
+      Log.e(
+        'Failed to generate link code: ${response.status} - ${response.data}',
+        label: _label,
+      );
+      return null;
     } catch (e, stack) {
-      Log.e('Error linking Telegram account: $e', label: _label);
+      Log.e('Error generating link code: $e', label: _label);
       Log.e('Stack: $stack', label: _label);
-      return false;
+      return null;
     }
   }
 

--- a/lib/features/ai_chat/data/services/bexly_agent_service.dart
+++ b/lib/features/ai_chat/data/services/bexly_agent_service.dart
@@ -167,7 +167,7 @@ class BexlyAgentService {
   static const _label = 'BexlyAgentService';
   static const _baseUrl = String.fromEnvironment(
     'BEXLY_AGENT_URL',
-    defaultValue: 'https://bexly-agent.dos.ai',
+    defaultValue: 'https://api.bexly.app',
   );
 
   /// Streams [AgentEvent]s from the Bexly Agent for [message].

--- a/lib/features/ai_chat/data/services/bexly_agent_service.dart
+++ b/lib/features/ai_chat/data/services/bexly_agent_service.dart
@@ -167,7 +167,7 @@ class BexlyAgentService {
   static const _label = 'BexlyAgentService';
   static const _baseUrl = String.fromEnvironment(
     'BEXLY_AGENT_URL',
-    defaultValue: 'https://api.bexly.app',
+    defaultValue: 'https://ai.bexly.app',
   );
 
   /// Streams [AgentEvent]s from the Bexly Agent for [message].

--- a/lib/features/settings/presentation/screens/bot_integration_screen.dart
+++ b/lib/features/settings/presentation/screens/bot_integration_screen.dart
@@ -17,6 +17,8 @@ class BotIntegrationScreen extends HookConsumerWidget {
     final isLoading = useState(false);
     final isTelegramLinked = useState<bool?>(null);
     final telegramId = useState<String?>(null);
+    final linkCode = useState<String?>(null);
+    final deepLink = useState<String?>(null);
 
     // Check Telegram link status on mount
     useEffect(() {
@@ -128,6 +130,7 @@ class BotIntegrationScreen extends HookConsumerWidget {
                     )
                   else
                     Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Container(
                           padding: const EdgeInsets.all(12),
@@ -141,7 +144,7 @@ class BotIntegrationScreen extends HookConsumerWidget {
                               Gap(12),
                               Expanded(
                                 child: Text(
-                                  'Not linked yet',
+                                  'Chưa liên kết',
                                   style: TextStyle(
                                     fontWeight: FontWeight.bold,
                                     color: Colors.orange,
@@ -152,28 +155,107 @@ class BotIntegrationScreen extends HookConsumerWidget {
                           ),
                         ),
                         const Gap(16),
-                        Text(
-                          'How to link:',
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                        const Gap(8),
-                        const Text(
-                          '1. Open Telegram and search for your bot\n'
-                          '2. Send any message to the bot\n'
-                          '3. Click the "🔗 Link Account" button\n'
-                          '4. App will open and link automatically',
-                          style: TextStyle(fontSize: 14),
-                        ),
-                        const Gap(16),
-                        FilledButton.icon(
-                          onPressed: () => _openTelegram(context),
-                          icon: const Icon(Icons.telegram),
-                          label: const Text('Open in Telegram'),
-                          style: FilledButton.styleFrom(
-                            minimumSize: const Size.fromHeight(48),
-                            backgroundColor: const Color(0xFF0088CC),
+                        if (linkCode.value == null) ...[
+                          const Text(
+                            'Tạo mã liên kết, mở Telegram và gửi mã cho bot '
+                            '(hoặc bấm nút mở sẵn). Sau khi bot xác nhận, bấm '
+                            '"Kiểm tra".',
+                            style: TextStyle(fontSize: 14),
                           ),
-                        ),
+                          const Gap(16),
+                          FilledButton.icon(
+                            onPressed: isLoading.value
+                                ? null
+                                : () => _generateCode(
+                                      context,
+                                      isLoading,
+                                      linkCode,
+                                      deepLink,
+                                    ),
+                            icon: const Icon(Icons.link),
+                            label: const Text('Tạo mã liên kết'),
+                            style: FilledButton.styleFrom(
+                              minimumSize: const Size.fromHeight(48),
+                              backgroundColor: const Color(0xFF0088CC),
+                            ),
+                          ),
+                        ] else ...[
+                          Text(
+                            'Mã liên kết của bạn:',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const Gap(8),
+                          Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                SelectableText(
+                                  linkCode.value!,
+                                  style: const TextStyle(
+                                    fontSize: 24,
+                                    fontWeight: FontWeight.bold,
+                                    letterSpacing: 4,
+                                  ),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.copy),
+                                  tooltip: 'Sao chép mã',
+                                  onPressed: () {
+                                    Clipboard.setData(
+                                      ClipboardData(text: linkCode.value!),
+                                    );
+                                    toastification.show(
+                                      context: context,
+                                      title: const Text('Đã sao chép mã'),
+                                      type: ToastificationType.success,
+                                      style: ToastificationStyle.fillColored,
+                                      autoCloseDuration:
+                                          const Duration(seconds: 2),
+                                    );
+                                  },
+                                ),
+                              ],
+                            ),
+                          ),
+                          const Gap(8),
+                          const Text(
+                            'Hết hạn sau 10 phút. Mở Telegram, gửi mã này cho '
+                            'bot (hoặc bấm nút bên dưới), rồi bấm "Kiểm tra".',
+                            style: TextStyle(fontSize: 13),
+                          ),
+                          const Gap(16),
+                          if (deepLink.value != null)
+                            FilledButton.icon(
+                              onPressed: () =>
+                                  _openDeepLink(context, deepLink.value!),
+                              icon: const Icon(Icons.telegram),
+                              label: const Text('Mở Telegram'),
+                              style: FilledButton.styleFrom(
+                                minimumSize: const Size.fromHeight(48),
+                                backgroundColor: const Color(0xFF0088CC),
+                              ),
+                            ),
+                          const Gap(8),
+                          OutlinedButton.icon(
+                            onPressed: isLoading.value
+                                ? null
+                                : () => _checkTelegramStatus(
+                                      isTelegramLinked,
+                                      telegramId,
+                                    ),
+                            icon: const Icon(Icons.refresh),
+                            label: const Text('Tôi đã gửi xong - Kiểm tra'),
+                            style: OutlinedButton.styleFrom(
+                              minimumSize: const Size.fromHeight(48),
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                 ],
@@ -249,32 +331,48 @@ class BotIntegrationScreen extends HookConsumerWidget {
     }
   }
 
-  Future<void> _openTelegram(BuildContext context) async {
-    // Open Telegram bot with pre-filled /link command
-    const botUsername = 'BexlyBot';
-    const url = 'https://t.me/$botUsername?text=/link';
-
+  Future<void> _generateCode(
+    BuildContext context,
+    ValueNotifier<bool> isLoading,
+    ValueNotifier<String?> linkCode,
+    ValueNotifier<String?> deepLink,
+  ) async {
+    isLoading.value = true;
     try {
-      await LinkLauncher.launch(url);
-
-      if (context.mounted) {
-        toastification.show(
-          context: context,
-          title: const Text('Opening Telegram'),
-          description: Text('Bot: @$botUsername'),
-          type: ToastificationType.info,
-          style: ToastificationStyle.fillColored,
-          autoCloseDuration: const Duration(seconds: 2),
-        );
+      final result = await TelegramBotService.generateLinkCode();
+      if (result != null && result['code'] is String) {
+        linkCode.value = result['code'] as String;
+        deepLink.value = result['deep_link'] as String?;
+      } else {
+        throw Exception('No code returned');
       }
     } catch (e) {
-      Log.e('Error opening Telegram: $e', label: 'BotIntegration');
-
+      Log.e('Error generating link code: $e', label: 'BotIntegration');
       if (context.mounted) {
         toastification.show(
           context: context,
-          title: const Text('Error'),
-          description: const Text('Failed to open Telegram. Please open it manually.'),
+          title: const Text('Lỗi'),
+          description: const Text('Không tạo được mã liên kết. Thử lại sau.'),
+          type: ToastificationType.error,
+          style: ToastificationStyle.fillColored,
+          autoCloseDuration: const Duration(seconds: 3),
+        );
+      }
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> _openDeepLink(BuildContext context, String url) async {
+    try {
+      await LinkLauncher.launch(url);
+    } catch (e) {
+      Log.e('Error opening Telegram: $e', label: 'BotIntegration');
+      if (context.mounted) {
+        toastification.show(
+          context: context,
+          title: const Text('Lỗi'),
+          description: const Text('Không mở được Telegram. Vui lòng mở thủ công.'),
           type: ToastificationType.error,
           style: ToastificationStyle.fillColored,
           autoCloseDuration: const Duration(seconds: 3),

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -135,8 +135,12 @@ Set via `supabase secrets set` before deploying:
 supabase secrets set BEXLY_ZALO_ACCESS_TOKEN=<oa_access_token>
 supabase secrets set BEXLY_ZALO_APP_SECRET=<oa_app_secret>
 supabase secrets set BEXLY_ZALO_USE_AGENT=true          # default false (maintenance mode)
-supabase secrets set BEXLY_AGENT_URL=https://bexly-agent.dos.ai
-# SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_JWT_SECRET are auto-injected
+supabase secrets set BEXLY_AGENT_URL=https://ai.bexly.app
+# Shared secret proving telegram/zalo webhooks are trusted backend callers
+# into the agent (the agent uses its own service key + this userId; webhooks
+# no longer forge a user JWT). Must match BEXLY_CHANNEL_SECRET set on Vercel.
+supabase secrets set BEXLY_CHANNEL_SECRET=<32+_char_shared_secret>
+# SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY are auto-injected
 ```
 
 ### OA Setup Flow

--- a/supabase/functions/_shared/supabase-client.ts
+++ b/supabase/functions/_shared/supabase-client.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 // Create Supabase client from environment variables
 export function createSupabaseClient() {
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabaseKey = Deno.env.get("BEXLY_SUPABASE_SECRET_KEY") ?? Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
   return createClient(supabaseUrl, supabaseKey, {
     db: { schema: "bexly" },

--- a/supabase/functions/link-telegram/index.ts
+++ b/supabase/functions/link-telegram/index.ts
@@ -60,95 +60,74 @@ serve(async (req) => {
     // Now use Bexly Supabase client for database operations
     const supabase = createSupabaseClient();
 
-    // Get request body
-    const body = await req.json();
-    let telegram_id = body.telegram_id;
+    const body = await req.json().catch(() => ({}));
+    const platform: string = body.platform === "zalo" ? "zalo" : "telegram";
 
-    // If link_code is provided, look up telegram_id from bot_link_codes table
-    if (body.link_code) {
-      console.log("[link-telegram] Verifying link_code:", body.link_code);
-      const { data: linkCode, error: codeError } = await supabase
-        .from("bot_link_codes")
-        .select("*")
-        .eq("code", body.link_code.toUpperCase())
-        .eq("platform", "telegram")
-        .gt("expires_at", new Date().toISOString())
-        .single();
-
-      if (codeError || !linkCode) {
-        console.error("[link-telegram] Invalid or expired link code:", codeError);
-        return new Response(
-          JSON.stringify({ error: "Invalid or expired link code" }),
-          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-        );
+    // Resolve the Telegram bot username for the deep-link (cached per cold
+    // start). Uses the bot token available as a Supabase secret to all
+    // functions; avoids a separate username secret that could drift.
+    const botToken = Deno.env.get("BEXLY_TELEGRAM_BOT_TOKEN");
+    let botUsername = "";
+    if (platform === "telegram" && botToken) {
+      try {
+        const me = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
+        const meJson = await me.json();
+        botUsername = meJson?.result?.username ?? "";
+      } catch (_) {
+        botUsername = "";
       }
+    }
 
-      telegram_id = linkCode.platform_user_id;
-      console.log("[link-telegram] Link code verified, telegram_id:", telegram_id);
+    // Generate a 6-char A-Z0-9 code; retry on the rare PK collision.
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    function genCode(): string {
+      let c = "";
+      for (let i = 0; i < 6; i++) {
+        c += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+      return c;
+    }
 
-      // Delete the used code
-      await supabase
+    // Clear this user's prior unused codes for the platform, then insert.
+    await supabase
+      .from("bot_link_codes")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("platform", platform);
+
+    let code = "";
+    let insertErr: unknown = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      code = genCode();
+      const { error } = await supabase
         .from("bot_link_codes")
-        .delete()
-        .eq("code", body.link_code.toUpperCase());
+        .insert({ code, user_id: user.id, platform });
+      if (!error) {
+        insertErr = null;
+        break;
+      }
+      insertErr = error;
     }
-
-    if (!telegram_id) {
+    if (insertErr) {
+      console.error("[link-telegram] code insert failed:", JSON.stringify(insertErr));
       return new Response(
-        JSON.stringify({ error: "telegram_id or link_code is required" }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
-    }
-
-    // Check if Telegram account is already linked
-    const { data: existing, error: checkError } = await supabase
-      .from("user_integrations")
-      .select("*")
-      .eq("platform", "telegram")
-      .eq("platform_user_id", String(telegram_id))
-      .single();
-
-    if (existing) {
-      return new Response(
-        JSON.stringify({
-          error: "This Telegram account is already linked to another user",
-        }),
-        { status: 409, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
-    }
-
-    // Create link
-    console.log("[link-telegram] Creating link for user:", user.id, "telegram_id:", telegram_id);
-    const { data: insertData, error: insertError } = await supabase
-      .from("user_integrations")
-      .insert({
-        user_id: user.id,
-        platform: "telegram",
-        platform_user_id: String(telegram_id),
-        linked_at: new Date().toISOString(),
-        last_activity: new Date().toISOString(),
-      })
-      .select();
-
-    if (insertError) {
-      console.error("[link-telegram] Error creating link:", JSON.stringify(insertError, null, 2));
-      return new Response(
-        JSON.stringify({
-          error: "Failed to link account",
-          details: insertError.message,
-          code: insertError.code
-        }),
+        JSON.stringify({ error: "Failed to generate link code" }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
       );
     }
 
-    console.log("[link-telegram] Link created successfully:", insertData);
+    const deepLink = botUsername
+      ? `https://t.me/${botUsername}?start=${code}`
+      : null;
 
+    console.log("[link-telegram] code generated for user", user.id, "platform", platform);
     return new Response(
       JSON.stringify({
         success: true,
-        message: "Telegram account linked successfully",
-        telegram_id: telegram_id,
+        code,
+        platform,
+        deep_link: deepLink,
+        expires_in_minutes: 10,
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );

--- a/supabase/functions/link-zalo/index.ts
+++ b/supabase/functions/link-zalo/index.ts
@@ -60,91 +60,52 @@ serve(async (req) => {
     // Now use Bexly Supabase client for database operations
     const supabase = createSupabaseClient();
 
-    // Get request body - expects { link_code: string }
-    const body = await req.json();
-
-    if (!body.link_code) {
-      return new Response(
-        JSON.stringify({ error: "link_code is required" }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
+    // Generate a 6-char A-Z0-9 code keyed by the authenticated Bexly user.
+    // Zalo OA has no deep-link start param; the user pastes the code into
+    // the OA chat, and zalo-webhook consumes it.
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    function genCode(): string {
+      let c = "";
+      for (let i = 0; i < 6; i++) {
+        c += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+      return c;
     }
 
-    console.log("[link-zalo] Verifying link_code:", body.link_code);
-    const { data: linkCode, error: codeError } = await supabase
-      .from("bot_link_codes")
-      .select("*")
-      .eq("code", body.link_code.toUpperCase())
-      .eq("platform", "zalo")
-      .gt("expires_at", new Date().toISOString())
-      .single();
-
-    if (codeError || !linkCode) {
-      console.error("[link-zalo] Invalid or expired link code:", codeError);
-      return new Response(
-        JSON.stringify({ error: "Invalid or expired link code" }),
-        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
-    }
-
-    const zaloUserId = linkCode.platform_user_id;
-    console.log("[link-zalo] Link code verified, zalo_user_id:", zaloUserId);
-
-    // Delete the used code
     await supabase
       .from("bot_link_codes")
       .delete()
-      .eq("code", body.link_code.toUpperCase());
+      .eq("user_id", user.id)
+      .eq("platform", "zalo");
 
-    // Check if this Zalo account is already linked to another Bexly user
-    const { data: existing } = await supabase
-      .from("user_integrations")
-      .select("*")
-      .eq("platform", "zalo")
-      .eq("platform_user_id", String(zaloUserId))
-      .single();
-
-    if (existing) {
-      return new Response(
-        JSON.stringify({
-          error: "This Zalo account is already linked to another user",
-        }),
-        { status: 409, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
+    let code = "";
+    let insertErr: unknown = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      code = genCode();
+      const { error } = await supabase
+        .from("bot_link_codes")
+        .insert({ code, user_id: user.id, platform: "zalo" });
+      if (!error) {
+        insertErr = null;
+        break;
+      }
+      insertErr = error;
     }
-
-    // Create the link in user_integrations
-    console.log("[link-zalo] Creating link for user:", user.id, "zalo_user_id:", zaloUserId);
-    const { data: insertData, error: insertError } = await supabase
-      .from("user_integrations")
-      .insert({
-        user_id: user.id,
-        platform: "zalo",
-        platform_user_id: String(zaloUserId),
-        linked_at: new Date().toISOString(),
-        last_activity: new Date().toISOString(),
-      })
-      .select();
-
-    if (insertError) {
-      console.error("[link-zalo] Error creating link:", JSON.stringify(insertError, null, 2));
+    if (insertErr) {
+      console.error("[link-zalo] code insert failed:", JSON.stringify(insertErr));
       return new Response(
-        JSON.stringify({
-          error: "Failed to link account",
-          details: insertError.message,
-          code: insertError.code
-        }),
+        JSON.stringify({ error: "Failed to generate link code" }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
       );
     }
 
-    console.log("[link-zalo] Link created successfully:", insertData);
-
+    console.log("[link-zalo] code generated for user", user.id);
     return new Response(
       JSON.stringify({
         success: true,
-        message: "Zalo account linked successfully",
-        zalo_user_id: zaloUserId,
+        code,
+        platform: "zalo",
+        expires_in_minutes: 10,
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -1,5 +1,15 @@
 // Telegram Webhook - Phase 3.2: routes to Bexly Agent when BEXLY_TELEGRAM_USE_AGENT=true,
 // otherwise uses legacy AI Transaction Processing + Financial Coach path.
+//
+// Required env (Supabase secrets):
+//   BEXLY_TELEGRAM_BOT_TOKEN  - Telegram bot token
+//   BEXLY_TELEGRAM_USE_AGENT  - "true" to route to the Bexly Agent
+//   BEXLY_AGENT_URL           - Bexly Agent base URL (default https://ai.bexly.app)
+//   BEXLY_CHANNEL_SECRET      - shared secret proving this is a trusted backend
+//                               caller into the agent (no forged user JWT);
+//                               must match BEXLY_CHANNEL_SECRET on Vercel
+//   SUPABASE_URL              - auto-injected
+//   SUPABASE_SERVICE_ROLE_KEY - auto-injected
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { parseTransactionWithAI } from "../_shared/ai-providers.ts";
@@ -11,9 +21,15 @@ import { buildCoachPrompt } from "../_shared/financial-coach-prompt.ts";
 const TELEGRAM_BOT_TOKEN = Deno.env.get("BEXLY_TELEGRAM_BOT_TOKEN");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const BEXLY_AGENT_URL = Deno.env.get("BEXLY_AGENT_URL") ?? "https://bexly-agent.dos.ai";
+const BEXLY_AGENT_URL = Deno.env.get("BEXLY_AGENT_URL") ?? "https://ai.bexly.app";
 const BEXLY_TELEGRAM_USE_AGENT = Deno.env.get("BEXLY_TELEGRAM_USE_AGENT") === "true";
-const SUPABASE_JWT_SECRET = Deno.env.get("SUPABASE_JWT_SECRET");
+// Shared secret for trusted server-to-server calls into the Bexly Agent.
+// The Supabase project signs user JWTs with asymmetric ES256 keys, so this
+// webhook cannot mint a matching user token. Instead it proves it is a
+// trusted backend caller with this secret and names the target user via the
+// X-Bexly-User-Id header; the agent uses its service key, scoping every
+// query by that userId.
+const BEXLY_CHANNEL_SECRET = Deno.env.get("BEXLY_CHANNEL_SECRET");
 
 function getSupabaseClient() {
   return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
@@ -21,49 +37,19 @@ function getSupabaseClient() {
   });
 }
 
-// ── Bexly Agent helpers (Phase 3.2) ──────────────────────────────────────────
+// ── Bexly Agent helpers (Phase 3.2; channel-auth as of channel-auth refactor) ─
 
-// Sign a short-lived user JWT for server-to-server calls into Bexly Agent.
-// Mirrors the structure of Supabase access tokens so the agent's
-// /auth/v1/user check accepts it.
-async function signUserJwt(userId: string, email?: string): Promise<string> {
-  if (!SUPABASE_JWT_SECRET) throw new Error('SUPABASE_JWT_SECRET not configured');
-  const header = { alg: 'HS256', typ: 'JWT' };
-  const now = Math.floor(Date.now() / 1000);
-  const payload = {
-    sub: userId,
-    aud: 'authenticated',
-    role: 'authenticated',
-    iat: now,
-    exp: now + 300, // 5 min
-    iss: `${Deno.env.get('SUPABASE_URL')}/auth/v1`,
-    ...(email ? { email } : {}),
-  };
-  const encode = (obj: object) =>
-    btoa(JSON.stringify(obj))
-      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  const signingInput = `${encode(header)}.${encode(payload)}`;
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(SUPABASE_JWT_SECRET),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingInput));
-  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  return `${signingInput}.${sigB64}`;
-}
-
-// POST a message to the Bexly Agent, accumulate streaming reply, return plain string.
+// POST a message to the Bexly Agent as a trusted channel caller and
+// accumulate the streamed reply into a plain string. Authenticates with the
+// shared channel secret + explicit user id (no forged JWT).
 async function callBexlyAgent(userId: string, message: string, threadId?: string): Promise<string> {
-  const jwt = await signUserJwt(userId);
+  if (!BEXLY_CHANNEL_SECRET) throw new Error('BEXLY_CHANNEL_SECRET not configured');
   const res = await fetch(`${BEXLY_AGENT_URL}/api/agent/chat`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${jwt}`,
       'Content-Type': 'application/json',
+      'X-Bexly-Channel-Secret': BEXLY_CHANNEL_SECRET,
+      'X-Bexly-User-Id': userId,
     },
     body: JSON.stringify({
       message,

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -74,15 +74,6 @@ async function callBexlyAgent(userId: string, message: string, threadId?: string
   return full.trim();
 }
 
-// ── Demo accounts for hackathon ──────────────────────────────────────────────
-const DEMO_ACCOUNTS = [
-  { num: 1, userId: "035bf828-fd7d-4210-9d57-5e8f9c2b9cda", name: "Minh", desc: "Office Worker - 20M VND/month, high dining spend" },
-  { num: 2, userId: "c50071e9-f4eb-464b-8b45-0d96c1c935ab", name: "Lan", desc: "Freelancer - irregular income, 8 subscriptions" },
-  { num: 3, userId: "43d7a628-2bde-445f-a8ff-8fdff1e5571b", name: "Huy", desc: "Student - tight budget, minimal savings" },
-  { num: 4, userId: "001531ce-bb0c-4070-b042-a7f62c5efa5f", name: "Trang", desc: "Business Owner - multi-currency, 4 wallets" },
-  { num: 5, userId: "a0ea0178-56c1-45b7-976f-9807a2078a3a", name: "Duc", desc: "Expat - USD+VND, international spending" },
-];
-
 // ── Telegram API helpers ──────────────────────────────────────────────────────
 
 // Convert Markdown-style `*bold*` / `_italic_` to Telegram HTML tags.
@@ -163,84 +154,56 @@ async function answerCallbackQuery(id: string, text?: string) {
 
 // ── Auth helpers ──────────────────────────────────────────────────────────────
 
-// Generate a random 6-char alphanumeric link code and store in DB
-async function generateLinkCode(telegramId: string): Promise<string> {
-  const code = Math.random().toString(36).substring(2, 8).toUpperCase();
-
-  // Delete any existing codes for this user
-  await getSupabaseClient()
-    .from("bot_link_codes")
-    .delete()
-    .eq("platform", "telegram")
-    .eq("platform_user_id", telegramId);
-
-  // Insert new code
-  await getSupabaseClient()
-    .from("bot_link_codes")
-    .insert({
-      code,
-      platform: "telegram",
-      platform_user_id: telegramId,
-    });
-
-  return code;
-}
-
+// Look up the Bexly user linked to this Telegram chat (null if unlinked).
 async function getUserId(telegramId: string): Promise<string | null> {
   const { data } = await getSupabaseClient()
     .from("user_integrations")
     .select("user_id")
     .eq("platform", "telegram")
     .eq("platform_user_id", telegramId)
-    .single();
+    .maybeSingle();
   return data?.user_id ?? null;
 }
 
-// Link telegram user to a demo account (upsert)
-async function linkToDemoAccount(telegramId: string, demoNum: number): Promise<boolean> {
-  const demo = DEMO_ACCOUNTS.find((d) => d.num === demoNum);
-  if (!demo) return false;
+// Consume an app-generated link code: validate (unexpired, telegram),
+// link this Telegram chat to the code's Bexly user, delete the code.
+// Returns the linked user_id, "ALREADY" if this chat is already linked,
+// or null if the code is invalid/expired.
+async function consumeLinkCode(
+  rawCode: string,
+  telegramId: string,
+): Promise<string | "ALREADY" | null> {
+  const code = rawCode.trim().toUpperCase();
+  const sb = getSupabaseClient();
 
-  // Delete existing link for this telegram user
-  await getSupabaseClient()
-    .from("user_integrations")
-    .delete()
+  const { data: row } = await sb
+    .from("bot_link_codes")
+    .select("user_id")
+    .eq("code", code)
     .eq("platform", "telegram")
-    .eq("platform_user_id", telegramId);
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+  if (!row?.user_id) return null;
 
-  // Insert new link
-  const { error } = await getSupabaseClient()
-    .from("user_integrations")
-    .insert({
-      user_id: demo.userId,
-      platform: "telegram",
-      platform_user_id: telegramId,
-    });
-
-  return !error;
-}
-
-async function showDemoSelector(chatId: number, prefix?: string) {
-  const lines = [
-    prefix || "👤 *Choose a demo account to explore:*",
-    "",
-  ];
-  for (const d of DEMO_ACCOUNTS) {
-    lines.push(`*${d.num}. ${d.name}* - ${d.desc}`);
+  const existing = await getUserId(telegramId);
+  if (existing) {
+    await sb.from("bot_link_codes").delete().eq("code", code);
+    return "ALREADY";
   }
-  lines.push("");
-  lines.push("_Tap a button below to select:_");
 
-  await sendMessage(chatId, lines.join("\n"), {
-    reply_markup: {
-      keyboard: [
-        DEMO_ACCOUNTS.slice(0, 3).map((d) => ({ text: `${d.num}. ${d.name}` })),
-        DEMO_ACCOUNTS.slice(3).map((d) => ({ text: `${d.num}. ${d.name}` })),
-      ],
-      one_time_keyboard: true,
-      resize_keyboard: true,
-    },
+  const { error: insErr } = await sb.from("user_integrations").insert({
+    user_id: row.user_id,
+    platform: "telegram",
+    platform_user_id: telegramId,
+    linked_at: new Date().toISOString(),
+    last_activity: new Date().toISOString(),
   });
+  if (insErr) {
+    console.error("[telegram-webhook] link insert failed:", JSON.stringify(insErr));
+    return null;
+  }
+  await sb.from("bot_link_codes").delete().eq("code", code);
+  return row.user_id;
 }
 
 async function unlinkUser(telegramId: string): Promise<boolean> {

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -713,26 +713,6 @@ serve(async (req) => {
         await answerCallbackQuery(cbId);
         await editMessageText(chatId, messageId, "✅ Cancelled. Account still linked.");
 
-      } else if (data.startsWith("demo_")) {
-        const demoNum = parseInt(data.slice(5));
-        const demo = DEMO_ACCOUNTS.find((d) => d.num === demoNum);
-        if (!demo) { await answerCallbackQuery(cbId, "Invalid demo"); return new Response("OK"); }
-
-        const ok = await linkToDemoAccount(telegramUserId, demoNum);
-        await answerCallbackQuery(cbId);
-        if (ok) {
-          await editMessageText(chatId, messageId,
-            `✅ *Switched to ${demo.name}'s account!*\n\n` +
-            `${demo.desc}\n\n` +
-            `Try these:\n` +
-            `• /insights - View spending overview\n` +
-            `• \`Tình hình tài chính?\` - Get coaching\n` +
-            `• \`ăn trưa 50k\` - Record expense\n` +
-            `• /demo - Switch account`
-          );
-        } else {
-          await editMessageText(chatId, messageId, "❌ Failed to switch. Try again.");
-        }
       }
 
       return new Response("OK", { status: 200 });
@@ -750,124 +730,72 @@ serve(async (req) => {
     const hasVietnamese = /[àáạảãâầấậẩẫăằắặẳẵèéẹẻẽêềếệểễìíịỉĩòóọỏõôồốộổỗơờớợởỡùúụủũưừứựửữỳýỵỷỹđ]/i.test(text);
     const lang = hasVietnamese || msg.from.language_code === "vi" ? "vi" : "en";
 
-    if (text === "/start") {
-      await sendMessage(chatId,
-        "👋 *Welcome to Bexly AI Financial Coach!*\n" +
-        "_Powered by Qwen AI & Shinhan Bank_\n\n" +
-        "I can:\n" +
-        "📝 Track expenses & income\n" +
-        "📊 Analyze your spending patterns\n" +
-        "💡 Give personalized financial coaching\n" +
-        "🏦 Recommend Shinhan banking products\n\n" +
-        "👇 *Pick a demo account to get started:*"
-      );
-      await showDemoSelector(chatId);
+    // Extract a link code from "/start <code>" or a bare 6-char message.
+    const startMatch = text.match(/^\/start(?:\s+([A-Za-z0-9]{6}))?$/);
+    const bareCodeMatch = text.match(/^([A-Za-z0-9]{6})$/);
+    const linkCode = startMatch?.[1] ?? (bareCodeMatch ? bareCodeMatch[1] : null);
+
+    if (linkCode) {
+      const result = await consumeLinkCode(linkCode, telegramUserId);
+      if (result === "ALREADY") {
+        await sendMessage(chatId,
+          "✅ Tài khoản Telegram này đã được liên kết. Cứ nhắn tin để dùng trợ lý Bexly.");
+      } else if (result) {
+        await sendMessage(chatId,
+          "✅ *Đã liên kết tài khoản Bexly!*\n\nNhắn tin cho tôi để ghi chép & hỏi về tài chính của bạn.");
+      } else {
+        await sendMessage(chatId,
+          "❌ Mã không hợp lệ hoặc đã hết hạn.\n\nMở app Bexly → Cài đặt → Liên kết Telegram để lấy mã mới.");
+      }
       return new Response("OK");
     }
 
-    if (text === "/demo") {
-      const existing = await getUserId(telegramUserId);
-      const currentDemo = existing ? DEMO_ACCOUNTS.find((d) => d.userId === existing) : null;
-      const prefix = currentDemo
-        ? `🔄 *Switch demo account*\n_Currently: ${currentDemo.name} (#${currentDemo.num})_`
-        : "👤 *Choose a demo account to explore:*";
-      await showDemoSelector(chatId, prefix);
+    if (text === "/start") {
+      await sendMessage(chatId,
+        "👋 *Chào mừng đến Bexly!*\n\n" +
+        "Tôi là trợ lý tài chính của bạn. Để bắt đầu:\n\n" +
+        "1. Mở app Bexly → *Cài đặt* → *Liên kết Telegram*\n" +
+        "2. Bấm nút mở Telegram (hoặc dán mã 6 ký tự vào đây)\n\n" +
+        "Sau khi liên kết, cứ nhắn tin để ghi chép & hỏi về tài chính.");
       return new Response("OK");
     }
 
     if (text === "/help") {
       await sendMessage(chatId,
-        "📖 *Bexly AI Coach Commands*\n\n" +
-        "/demo - Choose/switch demo account\n" +
-        "/insights - Spending overview & health score\n" +
-        "/link - Link your real Bexly account\n" +
-        "/unlink - Unlink your account\n" +
-        "/help - Show this help\n\n" +
-        "*Record transactions:*\n" +
-        "`ăn sáng 25k` - breakfast expense\n" +
-        "`lunch $10` - lunch expense\n" +
-        "`lương 15 triệu` - salary income\n\n" +
-        "*Ask for coaching:*\n" +
-        "`Tình hình tài chính tháng này?`\n" +
-        "`How can I save more?`\n" +
-        "`Nên cắt giảm chi tiêu gì?`"
-      );
-      return new Response("OK");
-    }
-
-    if (text === "/insights") {
-      const userId = await getUserId(telegramUserId);
-      if (!userId) {
-        await showDemoSelector(chatId, "📊 *Pick an account first to view insights:*");
-        return new Response("OK");
-      }
-      await handleInsightsCommand(chatId, userId, lang);
-      return new Response("OK");
-    }
-
-    if (text === "/link") {
-      const existing = await getUserId(telegramUserId);
-      if (existing) {
-        await sendMessage(chatId, "✅ Already linked! Just send a message to record a transaction.");
-        return new Response("OK");
-      }
-      const code = await generateLinkCode(telegramUserId);
-      await sendMessage(chatId,
-        `🔗 *Link your Bexly account*\n\n` +
-        `⌨️ Enter this code in Bexly app:\n\n` +
-        `\`${code}\`\n\n` +
-        `_(Settings → Integrations → Telegram)_\n` +
-        `⏰ Code expires in 10 minutes.`
-      );
+        "📖 *Bexly*\n\n" +
+        "/start - Bắt đầu / hướng dẫn liên kết\n" +
+        "/unlink - Huỷ liên kết tài khoản\n" +
+        "/help - Trợ giúp\n\n" +
+        "Đã liên kết? Cứ nhắn tự nhiên:\n" +
+        "`ăn sáng 25k` · `lương 15 triệu` · `Tháng này tôi tiêu bao nhiêu?`");
       return new Response("OK");
     }
 
     if (text === "/unlink") {
       const existing = await getUserId(telegramUserId);
       if (!existing) {
-        await sendMessage(chatId, "❌ Not linked yet. Use /link first.");
+        await sendMessage(chatId, "❌ Chưa liên kết. Mở app Bexly để liên kết trước.");
         return new Response("OK");
       }
-      await sendMessage(chatId, "⚠️ Unlink your Bexly account?", {
+      await sendMessage(chatId, "⚠️ Huỷ liên kết tài khoản Bexly?", {
         reply_markup: {
           inline_keyboard: [[
-            { text: "✅ Yes, unlink", callback_data: `unlink_confirm_${telegramUserId}` },
-            { text: "❌ Cancel", callback_data: `unlink_cancel_${telegramUserId}` },
+            { text: "✅ Huỷ liên kết", callback_data: `unlink_confirm_${telegramUserId}` },
+            { text: "❌ Thôi", callback_data: `unlink_cancel_${telegramUserId}` },
           ]],
         },
       });
       return new Response("OK");
     }
 
-    // Demo account selection via reply keyboard (e.g. "5. Duc")
-    const demoMatch = text.match(/^(\d)\.\s*(\w+)$/);
-    if (demoMatch) {
-      const demoNum = parseInt(demoMatch[1]);
-      const demo = DEMO_ACCOUNTS.find((d) => d.num === demoNum);
-      if (demo) {
-        const ok = await linkToDemoAccount(telegramUserId, demoNum);
-        if (ok) {
-          await sendMessage(chatId,
-            `✅ *Switched to ${demo.name}'s account!*\n\n` +
-            `${demo.desc}\n\n` +
-            `Try these:\n` +
-            `• /insights - View spending overview\n` +
-            `• \`Tình hình tài chính?\` - Get coaching\n` +
-            `• \`ăn trưa 50k\` - Record expense\n` +
-            `• /demo - Switch account`,
-            { reply_markup: { remove_keyboard: true } },
-          );
-        } else {
-          await sendMessage(chatId, "❌ Failed to switch. Try again.");
-        }
-        return new Response("OK");
-      }
-    }
-
-    // Any other message → try to parse as transaction
+    // Any other message requires a linked account.
     const userId = await getUserId(telegramUserId);
     if (!userId) {
-      await showDemoSelector(chatId, "👋 *Welcome!* Pick a demo account to get started:");
+      await sendMessage(chatId,
+        "🔗 Bạn chưa liên kết tài khoản Bexly.\n\n" +
+        "Mở app Bexly → *Cài đặt* → *Liên kết Telegram*, rồi bấm nút mở " +
+        "Telegram hoặc dán mã 6 ký tự vào đây.\n\n" +
+        "_Chưa có tài khoản Bexly? Tải app tại https://bexly.app_");
       return new Response("OK");
     }
 

--- a/supabase/functions/telegram-webhook/supabase-client.ts
+++ b/supabase/functions/telegram-webhook/supabase-client.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 // Create Supabase client from environment variables
 export function createSupabaseClient() {
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabaseKey = Deno.env.get("BEXLY_SUPABASE_SECRET_KEY") ?? Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
   return createClient(supabaseUrl, supabaseKey, {
     db: { schema: "bexly" },

--- a/supabase/functions/zalo-webhook/index.ts
+++ b/supabase/functions/zalo-webhook/index.ts
@@ -225,15 +225,28 @@ serve(async (req) => {
 
   console.log('[zalo-webhook] message from zaloUserId:', zaloUserId, '| text:', text.slice(0, 80))
 
+  // A bare 6-char message is treated as an app-generated link code.
+  const bareCode = text.match(/^([A-Za-z0-9]{6})$/)
+  if (bareCode) {
+    const result = await consumeZaloLinkCode(bareCode[1], zaloUserId)
+    if (result === 'ALREADY') {
+      await sendZaloMessage(zaloUserId, 'Tai khoan Zalo nay da duoc lien ket. Cu nhan tin de dung tro ly Bexly.')
+      return new Response('ok', { status: 200 })
+    }
+    if (result) {
+      await sendZaloMessage(zaloUserId, 'Da lien ket tai khoan Bexly! Nhan tin cho toi de ghi chep & hoi ve tai chinh.')
+      return new Response('ok', { status: 200 })
+    }
+    await sendZaloMessage(zaloUserId, 'Ma khong hop le hoac da het han. Mo app Bexly de lay ma moi.')
+    return new Response('ok', { status: 200 })
+  }
+
   const bexlyUserId = await getBexlyUserId(zaloUserId)
 
   if (!bexlyUserId) {
-    // Account not linked yet - generate a link code and prompt the user
-    const code = await generateZaloLinkCode(zaloUserId)
     await sendZaloMessage(
       zaloUserId,
-      `Chao ban! De lien ket voi tai khoan Bexly, vui long mo app Bexly va nhap ma: ${code}\n` +
-        `(Ma co hieu luc trong 10 phut.)`,
+      'Ban chua lien ket tai khoan Bexly. Mo app Bexly, vao Cai dat de lay ma 6 ky tu roi dan vao day.',
     )
     return new Response('ok', { status: 200 })
   }

--- a/supabase/functions/zalo-webhook/index.ts
+++ b/supabase/functions/zalo-webhook/index.ts
@@ -97,30 +97,45 @@ async function getBexlyUserId(zaloUserId: string): Promise<string | null> {
   return data?.user_id ?? null
 }
 
-// Generate a 6-char alphanumeric link code and store in bot_link_codes table.
-// Reuses the same table pattern as the Telegram channel (platform='zalo').
-async function generateZaloLinkCode(zaloUserId: string): Promise<string> {
-  const code = Math.random().toString(36).substring(2, 8).toUpperCase()
+// Consume an app-generated link code: validate (unexpired, zalo), link
+// this Zalo user to the code's Bexly user, delete the code. Returns the
+// linked user_id, "ALREADY" if this Zalo user is already linked, or null
+// if the code is invalid/expired.
+async function consumeZaloLinkCode(
+  rawCode: string,
+  zaloUserId: string,
+): Promise<string | 'ALREADY' | null> {
+  const code = rawCode.trim().toUpperCase()
+  const sb = getSupabaseClient()
 
-  const supabase = getSupabaseClient()
-
-  // Delete any existing pending codes for this Zalo user
-  await supabase
+  const { data: row } = await sb
     .from('bot_link_codes')
-    .delete()
+    .select('user_id')
+    .eq('code', code)
     .eq('platform', 'zalo')
-    .eq('platform_user_id', zaloUserId)
+    .gt('expires_at', new Date().toISOString())
+    .maybeSingle()
+  if (!row?.user_id) return null
 
-  // Insert new code
-  await supabase
-    .from('bot_link_codes')
-    .insert({
-      code,
-      platform: 'zalo',
-      platform_user_id: zaloUserId,
-    })
+  const existing = await getBexlyUserId(zaloUserId)
+  if (existing) {
+    await sb.from('bot_link_codes').delete().eq('code', code)
+    return 'ALREADY'
+  }
 
-  return code
+  const { error: insErr } = await sb.from('user_integrations').insert({
+    user_id: row.user_id,
+    platform: 'zalo',
+    platform_user_id: zaloUserId,
+    linked_at: new Date().toISOString(),
+    last_activity: new Date().toISOString(),
+  })
+  if (insErr) {
+    console.error('[zalo-webhook] link insert failed:', JSON.stringify(insErr))
+    return null
+  }
+  await sb.from('bot_link_codes').delete().eq('code', code)
+  return row.user_id
 }
 
 // POST message to the Bexly Agent as a trusted channel caller, accumulate the

--- a/supabase/functions/zalo-webhook/index.ts
+++ b/supabase/functions/zalo-webhook/index.ts
@@ -5,8 +5,9 @@
 //   BEXLY_ZALO_ACCESS_TOKEN  - OA access token from oa.zalo.me dashboard
 //   BEXLY_ZALO_APP_SECRET    - OA app secret (used for HMAC signature verify)
 //   BEXLY_ZALO_USE_AGENT     - "true" to route to agent; otherwise replies with maintenance notice
-//   BEXLY_AGENT_URL          - Bexly Agent base URL (default https://bexly-agent.dos.ai)
-//   SUPABASE_JWT_SECRET      - auto-injected; used to sign user JWT for /api/agent/chat
+//   BEXLY_AGENT_URL          - Bexly Agent base URL (default https://ai.bexly.app)
+//   BEXLY_CHANNEL_SECRET     - shared secret proving this is a trusted backend
+//                              caller into the agent (no forged user JWT)
 //   SUPABASE_URL             - auto-injected
 //   SUPABASE_SERVICE_ROLE_KEY - auto-injected
 //
@@ -20,10 +21,14 @@ import { createClient } from 'jsr:@supabase/supabase-js@2'
 const ZALO_ACCESS_TOKEN = Deno.env.get('BEXLY_ZALO_ACCESS_TOKEN')
 const ZALO_APP_SECRET = Deno.env.get('BEXLY_ZALO_APP_SECRET')
 const USE_AGENT = Deno.env.get('BEXLY_ZALO_USE_AGENT') === 'true'
-const BEXLY_AGENT_URL = Deno.env.get('BEXLY_AGENT_URL') ?? 'https://bexly-agent.dos.ai'
+const BEXLY_AGENT_URL = Deno.env.get('BEXLY_AGENT_URL') ?? 'https://ai.bexly.app'
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-const SUPABASE_JWT_SECRET = Deno.env.get('SUPABASE_JWT_SECRET')
+// Shared secret for trusted server-to-server calls into the Bexly Agent.
+// Supabase signs user JWTs with asymmetric ES256 keys, so this webhook
+// cannot mint a matching token; it authenticates as a trusted channel
+// caller instead and names the target user via X-Bexly-User-Id.
+const BEXLY_CHANNEL_SECRET = Deno.env.get('BEXLY_CHANNEL_SECRET')
 
 function getSupabaseClient() {
   return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
@@ -118,49 +123,18 @@ async function generateZaloLinkCode(zaloUserId: string): Promise<string> {
   return code
 }
 
-// Sign a short-lived user JWT for server-to-server calls into Bexly Agent.
-// Mirrors Supabase access token structure so the agent's auth check accepts it.
-async function signUserJwt(userId: string): Promise<string> {
-  if (!SUPABASE_JWT_SECRET) throw new Error('SUPABASE_JWT_SECRET not configured')
-  const header = { alg: 'HS256', typ: 'JWT' }
-  const now = Math.floor(Date.now() / 1000)
-  const payload = {
-    sub: userId,
-    aud: 'authenticated',
-    role: 'authenticated',
-    iat: now,
-    exp: now + 300, // 5 minutes
-    iss: `${SUPABASE_URL}/auth/v1`,
-  }
-  const encode = (obj: object) =>
-    btoa(JSON.stringify(obj))
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '')
-  const signingInput = `${encode(header)}.${encode(payload)}`
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(SUPABASE_JWT_SECRET),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  )
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingInput))
-  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
-  return `${signingInput}.${sigB64}`
-}
-
-// POST message to Bexly Agent, accumulate SSE/streaming reply, return plain text.
+// POST message to the Bexly Agent as a trusted channel caller, accumulate the
+// streamed reply, return plain text. Authenticates with the shared channel
+// secret + explicit user id instead of forging a user JWT (Supabase signs
+// user tokens with asymmetric ES256 keys; no shared HS256 secret exists).
 async function callBexlyAgent(bexlyUserId: string, message: string, threadId: string): Promise<string> {
-  const jwt = await signUserJwt(bexlyUserId)
+  if (!BEXLY_CHANNEL_SECRET) throw new Error('BEXLY_CHANNEL_SECRET not configured')
   const res = await fetch(`${BEXLY_AGENT_URL}/api/agent/chat`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${jwt}`,
       'Content-Type': 'application/json',
+      'X-Bexly-Channel-Secret': BEXLY_CHANNEL_SECRET,
+      'X-Bexly-User-Id': bexlyUserId,
     },
     body: JSON.stringify({ message, threadId, locale: 'vi' }),
   })

--- a/supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql
+++ b/supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql
@@ -1,0 +1,42 @@
+-- Recreate Bexly-owned bot-link tables destroyed as collateral of the
+-- 2026-04-30 `DROP SCHEMA bexly CASCADE` incident (DOS-AI team confirmed
+-- 2026-05-16 this was accidental, not a consolidation). Idempotent.
+-- Schema reconstructed from all 6 edge-function call-sites.
+
+CREATE TABLE IF NOT EXISTS bexly.user_integrations (
+  user_id          uuid        NOT NULL,
+  platform         text        NOT NULL CHECK (platform IN ('telegram','zalo')),
+  platform_user_id text        NOT NULL,
+  linked_at        timestamptz NOT NULL DEFAULT now(),
+  last_activity    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (platform, platform_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_integrations_user_id_idx
+  ON bexly.user_integrations (user_id);
+
+CREATE TABLE IF NOT EXISTS bexly.bot_link_codes (
+  code       text        NOT NULL,
+  user_id    uuid        NOT NULL,
+  platform   text        NOT NULL CHECK (platform IN ('telegram','zalo')),
+  expires_at timestamptz NOT NULL DEFAULT now() + interval '10 minutes',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (code)
+);
+
+ALTER TABLE bexly.user_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bexly.bot_link_codes    ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='bexly' AND tablename='user_integrations'
+      AND policyname='user_integrations_owner'
+  ) THEN
+    CREATE POLICY user_integrations_owner ON bexly.user_integrations
+      FOR ALL
+      USING (auth.uid() = user_id)
+      WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;

--- a/supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql
+++ b/supabase/migrations/20260516_recreate_bexly_bot_link_tables.sql
@@ -40,3 +40,12 @@ BEGIN
       WITH CHECK (auth.uid() = user_id);
   END IF;
 END $$;
+
+-- Table privileges for the PostgREST API roles. GRANT is independent of
+-- RLS (RLS filters rows; GRANT permits the operation at all). Without
+-- these, PostgREST returns 42501 "permission denied" even for
+-- service_role. authenticated is RLS-scoped by the owner policy above;
+-- bot_link_codes is service-role only (ephemeral internal).
+-- The modern sb_secret_* key maps to service_role. GRANT is idempotent.
+GRANT SELECT, INSERT, UPDATE, DELETE ON bexly.user_integrations TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON bexly.bot_link_codes TO service_role;


### PR DESCRIPTION
## Why

Bexly bot-link (Telegram/Zalo) prod cutover. Backend already applied to
prod ahead of this merge (gated steps now unblocked); this merge brings
`main` (and Flutter CI) in sync so the app builds the new
`bot_integration_screen`.

## Prod actions already completed (verified)

- **Migration applied** to prod `gulptwduchsjcsbndmua` (registered):
  `recreate_bexly_bot_link_tables` → `bexly.user_integrations` +
  `bexly.bot_link_codes` (idempotent `CREATE TABLE IF NOT EXISTS`, RLS
  enabled, owner policy on user_integrations, GRANTs to
  authenticated/service_role). Verified: 2 tables, RLS on both, owner
  policy present, grants correct. Security advisor: only the by-design
  INFO `rls_enabled_no_policy` on bot_link_codes (service-role-only
  ephemeral, same pattern as family_groups/shared_wallets).
- **4 edge functions deployed** to prod with `--no-verify-jwt`:
  telegram-webhook v116, link-telegram v63, zalo-webhook v9, link-zalo
  v8. Smoke: `link-telegram` no-auth → clean JSON 401 from function body
  (not gateway); `zalo-webhook` GET → 200 "ok" (webhook verify path).

## In this PR

- Bot-link redesign: app-generates-code → bot-consumes flow (5 plans,
  beta-verified). 4 functions rewritten + `_shared/supabase-client.ts`
  (BEXLY_SUPABASE_SECRET_KEY), Flutter `bot_integration_screen` +
  `telegram_bot_service`, migration file, demo-picker removed.
- `fix(edge)`: declare `verify_jwt=false` for `link-zalo` +
  `zalo-webhook` in config.toml (was missing → a future CLI deploy would
  default them to true and break the Zalo bot).

## Notes

- Zalo real-message E2E still needs `BEXLY_ZALO_ACCESS_TOKEN` /
  `BEXLY_ZALO_APP_SECRET` (Zalo OA registration — JOY-pending, external).
- Telegram path E2E-verified on beta (Plans 1-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)